### PR TITLE
Fix rest v1 regression

### DIFF
--- a/WaarpR66/src/main/java/org/waarp/openr66/context/ErrorCode.java
+++ b/WaarpR66/src/main/java/org/waarp/openr66/context/ErrorCode.java
@@ -19,6 +19,8 @@
  */
 package org.waarp.openr66.context;
 
+import com.fasterxml.jackson.annotation.JsonValue;
+
 import org.waarp.openr66.protocol.configuration.Messages;
 
 /**
@@ -175,6 +177,11 @@ public enum ErrorCode {
 
   ErrorCode(char code) {
     this.code = code;
+  }
+
+  @JsonValue
+  public String getJsonRepr() {
+    return String.valueOf(code)+"  ";
   }
 
   public String getCode() {

--- a/WaarpR66/src/main/java/org/waarp/openr66/pojo/Business.java
+++ b/WaarpR66/src/main/java/org/waarp/openr66/pojo/Business.java
@@ -20,21 +20,29 @@
 
 package org.waarp.openr66.pojo;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 /**
  * Business data object
  */
 public class Business {
 
+  @JsonProperty("HOSTID")
   private String hostid;
 
+  @JsonProperty("BUSINESS")
   private String business;
 
+  @JsonProperty("ROLES")
   private String roles;
 
+  @JsonProperty("ALIASES")
   private String aliases;
 
+  @JsonProperty("OTHERS")
   private String others;
 
+  @JsonProperty("UPDATEDINFO")
   private UpdatedInfo updatedInfo = UpdatedInfo.UNKNOWN;
 
   /**

--- a/WaarpR66/src/main/java/org/waarp/openr66/pojo/Host.java
+++ b/WaarpR66/src/main/java/org/waarp/openr66/pojo/Host.java
@@ -20,6 +20,9 @@
 
 package org.waarp.openr66.pojo;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
@@ -38,32 +41,42 @@ public class Host {
   private static final int DEFAULT_CLIENT_PORT = 0;
 
   @XmlElement(name = XML_AUTHENTIFICATION_HOSTID)
+  @JsonProperty("HOSTID")
   private String hostid;
 
   @XmlElement(name = XML_AUTHENTIFICATION_ADDRESS)
+  @JsonProperty("ADDRESS")
   private String address;
 
   @XmlElement(name = XML_AUTHENTIFICATION_PORT)
+  @JsonProperty("PORT")
   private int port;
 
   @XmlTransient
+  @JsonProperty("HOSTKEY")
   private byte[] hostkey;
 
   @XmlElement(name = XML_AUTHENTIFICATION_ISSSL)
+  @JsonProperty("ISSSL")
   private boolean ssl;
 
   @XmlElement(name = XML_AUTHENTIFICATION_ISCLIENT)
+  @JsonProperty("ISCLIENT")
   private boolean client;
 
   @XmlElement(name = XML_AUTHENTIFICATION_ISPROXIFIED)
+  @JsonProperty("ISPROXIFIED")
   private boolean proxified;
 
   @XmlElement(name = XML_AUTHENTIFICATION_ADMIN)
+  @JsonProperty("ADMINROLE")
   private boolean admin = true;
 
   @XmlElement(name = XML_AUTHENTIFICATION_ISACTIVE)
+  @JsonProperty("ISACTIVE")
   private boolean active = true;
 
+  @JsonProperty("UPDATEDINFO")
   private UpdatedInfo updatedInfo = UpdatedInfo.UNKNOWN;
 
   /**
@@ -140,6 +153,7 @@ public class Host {
   }
 
   @XmlElement(name = XML_AUTHENTIFICATION_KEY)
+  @JsonIgnore
   public String getKey() {
     return new String(hostkey);
   }

--- a/WaarpR66/src/main/java/org/waarp/openr66/pojo/Limit.java
+++ b/WaarpR66/src/main/java/org/waarp/openr66/pojo/Limit.java
@@ -20,23 +20,32 @@
 
 package org.waarp.openr66.pojo;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 /**
  * Limit data object
  */
 public class Limit {
 
+  @JsonProperty("HOSTID")
   private String hostid;
 
+  @JsonProperty("READGLOBALLIMIT")
   private long readGlobalLimit;
 
+  @JsonProperty("WRITEGLOBALLIMIT")
   private long writeGlobalLimit;
 
+  @JsonProperty("READSESSIONLIMIT")
   private long readSessionLimit;
 
+  @JsonProperty("WRITESESSIONLIMIT")
   private long writeSessionLimit;
 
+  @JsonProperty("DELAYLIMIT")
   private long delayLimit;
 
+  @JsonProperty("UPDATEDINFO")
   private UpdatedInfo updatedInfo = UpdatedInfo.UNKNOWN;
 
   /**

--- a/WaarpR66/src/main/java/org/waarp/openr66/pojo/Rule.java
+++ b/WaarpR66/src/main/java/org/waarp/openr66/pojo/Rule.java
@@ -29,6 +29,10 @@ import javax.xml.bind.annotation.XmlElementDecl;
 import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlTransient;
 import javax.xml.bind.annotation.XmlType;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -42,45 +46,59 @@ import static org.waarp.openr66.configuration.RuleFileBasedConfiguration.*;
 public class Rule {
 
   @XmlElement(name = XIDRULE)
+  @JsonProperty("IDRULE")
   private String name;
 
   @XmlElement(name = XMODE)
+  @JsonProperty("MODETRANS")
   private int mode;
 
   @XmlElementWrapper(name = XHOSTIDS)
   @XmlElement(name = XHOSTID)
+  @JsonIgnore
   private List<String> hostids;
 
   @XmlElement(name = XRECVPATH, required = true)
+  @JsonProperty("RECVPATH")
   private String recvPath;
 
   @XmlElement(name = XSENDPATH, required = true)
+  @JsonProperty("SENDPATH")
   private String sendPath;
 
   @XmlElement(name = XARCHIVEPATH, required = true)
+  @JsonProperty("ARCHIVEPATH")
   private String archivePath;
 
   @XmlElement(name = XWORKPATH, required = true)
+  @JsonProperty("WORKPATH")
   private String workPath;
 
   @XmlTransient
+  @JsonIgnore
   private List<RuleTask> rPreTasks;
 
   @XmlTransient
+  @JsonIgnore
   private List<RuleTask> rPostTasks;
 
   @XmlTransient
+  @JsonIgnore
   private List<RuleTask> rErrorTasks;
 
   @XmlTransient
+  @JsonIgnore
   private List<RuleTask> sPreTasks;
 
   @XmlTransient
+  @JsonIgnore
   private List<RuleTask> sPostTasks;
 
   @XmlTransient
+  @JsonIgnore
   private List<RuleTask> sErrorTasks;
 
+  @JsonProperty("UPDATEDINFO")
   private UpdatedInfo updatedInfo = UpdatedInfo.UNKNOWN;
 
   /**
@@ -98,36 +116,42 @@ public class Rule {
 
   @XmlElementDecl(name = XRPRETASKS)
   @XmlElement(name = XRPRETASKS)
+  @JsonIgnore
   public Tasks get_rPreTasks() {
     return new Tasks(rPreTasks);
   }
 
   @XmlElementDecl(name = XRPOSTTASKS)
   @XmlElement(name = XRPOSTTASKS)
+  @JsonIgnore
   public Tasks get_rPostTasks() {
     return new Tasks(rPostTasks);
   }
 
   @XmlElementDecl(name = XRERRORTASKS)
   @XmlElement(name = XRERRORTASKS)
+  @JsonIgnore
   public Tasks get_rErrorTasks() {
     return new Tasks(rErrorTasks);
   }
 
   @XmlElementDecl(name = XSPRETASKS)
   @XmlElement(name = XSPRETASKS)
+  @JsonIgnore
   public Tasks get_sPreTasks() {
     return new Tasks(sPreTasks);
   }
 
   @XmlElementDecl(name = XSPOSTTASKS)
   @XmlElement(name = XSPOSTTASKS)
+  @JsonIgnore
   public Tasks get_sPostTasks() {
     return new Tasks(sPostTasks);
   }
 
   @XmlElementDecl(name = XSERRORTASKS)
   @XmlElement(name = XSERRORTASKS)
+  @JsonIgnore
   public Tasks get_sErrorTasks() {
     return new Tasks(sErrorTasks);
   }
@@ -182,6 +206,7 @@ public class Rule {
     return hostids.contains(hostid);
   }
 
+  @JsonProperty("HOSTIDS")
   public String getXMLHostids() {
     StringBuilder res = new StringBuilder("<hostids>");
     for (final String hostid : hostids) {
@@ -190,26 +215,32 @@ public class Rule {
     return res.append("</hostids>").toString();
   }
 
+  @JsonProperty("RPRETASKS")
   public String getXMLRPreTasks() {
     return getXMLTasks(rPreTasks);
   }
 
+  @JsonProperty("RPOSTTASKS")
   public String getXMLRPostTasks() {
     return getXMLTasks(rPostTasks);
   }
 
+  @JsonProperty("RERRORTASKS")
   public String getXMLRErrorTasks() {
     return getXMLTasks(rErrorTasks);
   }
 
+  @JsonProperty("SPRETASKS")
   public String getXMLSPreTasks() {
     return getXMLTasks(sPreTasks);
   }
 
+  @JsonProperty("SPOSTTASKS")
   public String getXMLSPostTasks() {
     return getXMLTasks(sPostTasks);
   }
 
+  @JsonProperty("SERRORTASKS")
   public String getXMLSErrorTasks() {
     return getXMLTasks(sErrorTasks);
   }
@@ -278,6 +309,7 @@ public class Rule {
     this.workPath = workPath;
   }
 
+  @JsonIgnore
   public List<RuleTask> getRPreTasks() {
     return rPreTasks;
   }
@@ -286,6 +318,7 @@ public class Rule {
     this.rPreTasks = rPreTasks;
   }
 
+  @JsonIgnore
   public List<RuleTask> getRPostTasks() {
     return rPostTasks;
   }
@@ -294,6 +327,7 @@ public class Rule {
     this.rPostTasks = rPostTasks;
   }
 
+  @JsonIgnore
   public List<RuleTask> getRErrorTasks() {
     return rErrorTasks;
   }
@@ -302,6 +336,7 @@ public class Rule {
     this.rErrorTasks = rErrorTasks;
   }
 
+  @JsonIgnore
   public List<RuleTask> getSPreTasks() {
     return sPreTasks;
   }
@@ -310,6 +345,7 @@ public class Rule {
     this.sPreTasks = sPreTasks;
   }
 
+  @JsonIgnore
   public List<RuleTask> getSPostTasks() {
     return sPostTasks;
   }
@@ -318,6 +354,7 @@ public class Rule {
     this.sPostTasks = sPostTasks;
   }
 
+  @JsonIgnore
   public List<RuleTask> getSErrorTasks() {
     return sErrorTasks;
   }

--- a/WaarpR66/src/main/java/org/waarp/openr66/pojo/Rule.java
+++ b/WaarpR66/src/main/java/org/waarp/openr66/pojo/Rule.java
@@ -32,6 +32,7 @@ import javax.xml.bind.annotation.XmlType;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -43,6 +44,11 @@ import static org.waarp.openr66.configuration.RuleFileBasedConfiguration.*;
  */
 @XmlType(name = ROOT)
 @XmlAccessorType(XmlAccessType.FIELD)
+@JsonPropertyOrder({
+    "IDRULE", "MODETRANS", "RECVPATH", "SENDPATH", "ARCHIVEPATH",
+    "WORKPATH", "UPDATEDINFO", "HOSTIDS", "SPRETASKS", "SPOSTASKS", "SERRORTASKS",
+    "RPRETASKS", "RPOSTTASKS", "RERRORTASKS"
+})
 public class Rule {
 
   @XmlElement(name = XIDRULE)

--- a/WaarpR66/src/main/java/org/waarp/openr66/pojo/Transfer.java
+++ b/WaarpR66/src/main/java/org/waarp/openr66/pojo/Transfer.java
@@ -27,6 +27,10 @@ import org.waarp.openr66.database.DbConstantR66;
 import org.waarp.openr66.database.data.DbTaskRunner;
 import org.waarp.openr66.protocol.configuration.Configuration;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
@@ -77,9 +81,15 @@ public class Transfer {
     public DbTaskRunner.TASKSTEP toLegacy() {
       return DbTaskRunner.TASKSTEP.valueOf(name());
     }
+
+    @JsonValue
+    public int getTaskNo() {
+        return taskNo;
+    }
   }
 
   @XmlElement(name = ID_FIELD)
+  @JsonProperty("SPECIALID")
   private long id = DbConstantR66.ILLEGALVALUE;
 
   /**
@@ -88,69 +98,91 @@ public class Transfer {
    * (RETRIEVE MODE)
    */
   @XmlElement(name = RETRIEVE_MODE_FIELD)
+  @JsonProperty("RETRIEVEMODE")
   private boolean retrieveMode;
 
   @XmlElement(name = ID_RULE_FIELD)
+  @JsonProperty("IDRULE")
   private String rule = "";
 
   @XmlElement(name = TRANSFER_MODE_FIELD)
+  @JsonProperty("MODETRANS")
   private int transferMode = 1;
 
   @XmlElement(name = FILENAME_FIELD)
+  @JsonProperty("FILENAME")
   private String filename = "";
 
   @XmlElement(name = ORIGINAL_NAME_FIELD)
+  @JsonProperty("ORIGINALNAME")
   private String originalName = "";
 
   @XmlElement(name = FILE_INFO_FIELD)
+  @JsonProperty("FILEINFO")
   private String fileInfo = "";
 
   @XmlElement(name = IS_MOVED_FIELD)
-  private boolean isFileMoved;
+  @JsonProperty("ISMOVED")
+  private boolean isMoved;
 
   @XmlElement(name = BLOCK_SIZE_FIELD)
+  @JsonProperty("BLOCKSZ")
   private int blockSize;
 
   @XmlElement(name = OWNER_REQUEST_FIELD)
+  @JsonProperty("OWNERREQ")
   private String ownerRequest = Configuration.configuration.getHostId();
 
   @XmlElement(name = REQUESTER_FIELD)
+  @JsonProperty("REQUESTER")
   private String requester = "";
 
   @XmlElement(name = REQUESTED_FIELD)
+  @JsonProperty("REQUESTED")
   private String requested = "";
 
   @XmlTransient
+  @JsonProperty("TRANSFERINFO")
   private String transferInfo = "";
 
   @XmlElement(name = GLOBAL_STEP_FIELD)
+  @JsonProperty("GLOBALSTEP")
   private TASKSTEP globalStep = TASKSTEP.NOTASK;
 
   @XmlElement(name = GLOBAL_LAST_STEP_FIELD)
+  @JsonProperty("GLOBALLASTSTEP")
   private TASKSTEP lastGlobalStep = TASKSTEP.NOTASK;
 
   @XmlElement(name = STEP_FIELD)
+  @JsonProperty("STEP")
   private int step = -1;
 
   @XmlElement(name = STEP_STATUS_FIELD)
+  @JsonProperty("STEPSTATUS")
   private ErrorCode stepStatus = ErrorCode.Unknown;
 
   @XmlElement(name = INFO_STATUS_FIELD)
+  @JsonProperty("INFOSTATUS")
   private ErrorCode infoStatus = ErrorCode.Unknown;
 
   @XmlElement(name = RANK_FIELD)
+  @JsonProperty("RANK")
   private int rank;
 
   @XmlTransient
+  @JsonProperty("STARTTRANS")
   private Timestamp start = new Timestamp(0);
 
   @XmlTransient
+  @JsonProperty("STOPTRANS")
   private Timestamp stop = new Timestamp(0);
 
   @XmlTransient
+  @JsonProperty("UPDATEDINFO")
   private UpdatedInfo updatedInfo = UpdatedInfo.UNKNOWN;
 
   @XmlElement(name = TRANSFER_START_FIELD)
+  @JsonIgnore
   public long getXmlStart() {
     return start.getTime();
   }
@@ -160,6 +192,7 @@ public class Transfer {
   }
 
   @XmlElement(name = TRANSFER_STOP_FIELD)
+  @JsonIgnore
   public long getXmlStop() {
     return stop.getTime();
   }
@@ -177,7 +210,7 @@ public class Transfer {
    * @param filename
    * @param originalName
    * @param fileInfo
-   * @param isFileMoved
+   * @param isMoved
    * @param blockSize
    * @param retrieveMode
    * @param ownerReq
@@ -195,13 +228,13 @@ public class Transfer {
    * @param updatedInfo
    */
   public Transfer(long id, String rule, int mode, String filename,
-                  String originalName, String fileInfo, boolean isFileMoved,
+                  String originalName, String fileInfo, boolean isMoved,
                   int blockSize, boolean retrieveMode, String ownerReq,
                   String requester, String requested, String transferInfo,
                   TASKSTEP globalStep, TASKSTEP lastGlobalStep, int step,
                   ErrorCode stepStatus, ErrorCode infoStatus, int rank,
                   Timestamp start, Timestamp stop, UpdatedInfo updatedInfo) {
-    this(id, rule, mode, filename, originalName, fileInfo, isFileMoved,
+    this(id, rule, mode, filename, originalName, fileInfo, isMoved,
          blockSize, retrieveMode, ownerReq, requester, requested, transferInfo,
          globalStep, lastGlobalStep, step, stepStatus, infoStatus, rank, start,
          stop);
@@ -217,7 +250,7 @@ public class Transfer {
    * @param filename
    * @param originalName
    * @param fileInfo
-   * @param isFileMoved
+   * @param isMoved
    * @param blockSize
    * @param retrieveMode
    * @param ownerReq
@@ -234,7 +267,7 @@ public class Transfer {
    * @param stop
    */
   public Transfer(long id, String rule, int mode, String filename,
-                  String originalName, String fileInfo, boolean isFileMoved,
+                  String originalName, String fileInfo, boolean isMoved,
                   int blockSize, boolean retrieveMode, String ownerReq,
                   String requester, String requested, String transferInfo,
                   TASKSTEP globalStep, TASKSTEP lastGlobalStep, int step,
@@ -247,7 +280,7 @@ public class Transfer {
     this.filename = filename;
     this.originalName = originalName;
     this.fileInfo = fileInfo;
-    this.isFileMoved = isFileMoved;
+    this.isMoved = isMoved;
     this.blockSize = blockSize;
     ownerRequest = ownerReq;
     this.requester = requester;
@@ -369,11 +402,11 @@ public class Transfer {
   }
 
   public boolean getIsMoved() {
-    return isFileMoved;
+    return isMoved;
   }
 
-  public void setIsMoved(boolean isFileMoved) {
-    this.isFileMoved = isFileMoved;
+  public void setIsMoved(boolean isMoved) {
+    this.isMoved = isMoved;
   }
 
   public int getBlockSize() {

--- a/WaarpR66/src/main/java/org/waarp/openr66/pojo/UpdatedInfo.java
+++ b/WaarpR66/src/main/java/org/waarp/openr66/pojo/UpdatedInfo.java
@@ -20,6 +20,8 @@
 
 package org.waarp.openr66.pojo;
 
+import com.fasterxml.jackson.annotation.JsonValue;
+
 import org.waarp.common.database.data.AbstractDbData;
 
 import java.util.HashMap;
@@ -87,5 +89,10 @@ public enum UpdatedInfo {
 
   public AbstractDbData.UpdatedInfo getLegacy() {
     return AbstractDbData.UpdatedInfo.valueOf(name());
+  }
+
+  @JsonValue
+  public int getID() {
+  	return id;
   }
 }

--- a/WaarpR66/src/test/java/org/waarp/openr66/database/data/DbConfigurationTest.java
+++ b/WaarpR66/src/test/java/org/waarp/openr66/database/data/DbConfigurationTest.java
@@ -1,0 +1,56 @@
+/*
+ * This file is part of Waarp Project (named also Waarp or GG).
+ *
+ *  Copyright (c) 2019, Waarp SAS, and individual contributors by the @author
+ *  tags. See the COPYRIGHT.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ *  All Waarp Project is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * Waarp is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ * Waarp . If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.waarp.openr66.database.data;
+
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import org.junit.Test;
+import org.waarp.common.json.JsonHandler;
+import org.waarp.openr66.pojo.Limit;
+import org.waarp.openr66.pojo.UpdatedInfo;
+
+import static org.junit.Assert.*;
+
+public class DbConfigurationTest {
+    @Test
+    public void testJsonSerialisation() {
+		Limit limit = new Limit("hostid",10, 20, 30, 40, 50, UpdatedInfo.TOSUBMIT);
+        DbConfiguration dbConf = new DbConfiguration(limit);
+
+        String expected = "{" +
+            "\"@model\":\"DbConfiguration\"," +
+            "\"HOSTID\":\"hostid\"," +
+            "\"READGLOBALLIMIT\":20," +
+            "\"WRITEGLOBALLIMIT\":30," +
+            "\"READSESSIONLIMIT\":40," +
+            "\"WRITESESSIONLIMIT\":50," +
+            "\"DELAYLIMIT\":10," +
+            "\"UPDATEDINFO\":3" +
+            "}";
+
+
+        ObjectNode asJson = dbConf.getJson();
+        String got = JsonHandler.writeAsString(asJson);
+
+        assertEquals(expected, got);
+    }
+}

--- a/WaarpR66/src/test/java/org/waarp/openr66/database/data/DbHostAuthTest.java
+++ b/WaarpR66/src/test/java/org/waarp/openr66/database/data/DbHostAuthTest.java
@@ -1,0 +1,58 @@
+/*
+ * This file is part of Waarp Project (named also Waarp or GG).
+ *
+ *  Copyright (c) 2019, Waarp SAS, and individual contributors by the @author
+ *  tags. See the COPYRIGHT.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ *  All Waarp Project is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * Waarp is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ * Waarp . If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.waarp.openr66.database.data;
+
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import org.junit.Test;
+import org.waarp.common.json.JsonHandler;
+
+import static org.junit.Assert.*;
+
+
+public class DbHostAuthTest {
+    @Test
+    public void testJsonSerialisation() {
+        DbHostAuth dbHostConf = new DbHostAuth("hostid", "127.0.0.1", 6666,
+                false, null, true, true);
+
+        String expected = "{" +
+                "\"@model\":\"DbHostAuth\"," +
+                "\"HOSTID\":\"hostid\"," +
+                "\"ADDRESS\":\"127.0.0.1\"," +
+                "\"PORT\":6666," +
+                "\"HOSTKEY\":null," +
+                "\"ISSSL\":false," +
+                "\"ISCLIENT\":true," +
+                "\"ISPROXIFIED\":false," +
+                "\"ADMINROLE\":true," +
+                "\"ISACTIVE\":true," +
+                "\"UPDATEDINFO\":0" +
+            "}";
+
+
+        ObjectNode asJson = dbHostConf.getJson();
+        String got = JsonHandler.writeAsString(asJson);
+
+        assertEquals(expected, got);
+    }
+}

--- a/WaarpR66/src/test/java/org/waarp/openr66/database/data/DbHostConfigurationTest.java
+++ b/WaarpR66/src/test/java/org/waarp/openr66/database/data/DbHostConfigurationTest.java
@@ -1,0 +1,56 @@
+/*
+ * This file is part of Waarp Project (named also Waarp or GG).
+ *
+ *  Copyright (c) 2019, Waarp SAS, and individual contributors by the @author
+ *  tags. See the COPYRIGHT.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ *  All Waarp Project is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * Waarp is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ * Waarp . If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.waarp.openr66.database.data;
+
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import org.junit.Test;
+import org.waarp.common.json.JsonHandler;
+import org.waarp.openr66.pojo.Business;
+import org.waarp.openr66.pojo.UpdatedInfo;
+
+import static org.junit.Assert.*;
+
+public class DbHostConfigurationTest {
+    @Test
+    public void testJsonSerialisation() {
+		Business business = new Business("Test", "business", "roles", "aliases",
+                "others", UpdatedInfo.UNKNOWN);
+        DbHostConfiguration dbHostConf = new DbHostConfiguration(business);
+
+        String expected = "{" +
+            "\"@model\":\"DbHostConfiguration\"," +
+            "\"HOSTID\":\"Test\"," +
+            "\"BUSINESS\":\"business\"," +
+            "\"ROLES\":\"roles\"," +
+            "\"ALIASES\":\"aliases\"," +
+            "\"OTHERS\":\"others\"," +
+            "\"UPDATEDINFO\":0" +
+            "}";
+
+
+        ObjectNode asJson = dbHostConf.getJson();
+        String got = JsonHandler.writeAsString(asJson);
+
+        assertEquals(expected, got);
+    }
+}

--- a/WaarpR66/src/test/java/org/waarp/openr66/database/data/DbRuleTest.java
+++ b/WaarpR66/src/test/java/org/waarp/openr66/database/data/DbRuleTest.java
@@ -22,6 +22,7 @@ package org.waarp.openr66.database.data;
 
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.ArrayListMultimap;
 
 import org.junit.Ignore;
 import org.junit.Test;
@@ -32,18 +33,36 @@ import org.waarp.openr66.pojo.UpdatedInfo;
 
 import static org.junit.Assert.*;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 public class DbRuleTest {
     @Test
-    @Ignore
     public void testJsonSerialisation() {
         List<String> hosts = Arrays.asList("sup1");
-        List<RuleTask> tasks = Arrays.asList();
+
+        List<RuleTask> spretasks = new ArrayList<RuleTask>();
+        spretasks.add(new RuleTask("LOG", "spretasks", 0));
+
+        List<RuleTask> sposttasks = new ArrayList<RuleTask>();
+        sposttasks.add(new RuleTask("LOG", "sposttasks", 0));
+
+        List<RuleTask> serrortasks = new ArrayList<RuleTask>();
+        serrortasks.add(new RuleTask("LOG", "serrortasks", 0));
+
+        List<RuleTask> rpretasks = new ArrayList<RuleTask>();
+        rpretasks.add(new RuleTask("LOG", "rpretasks", 0));
+
+        List<RuleTask> rposttasks = new ArrayList<RuleTask>();
+        rposttasks.add(new RuleTask("LOG", "rposttasks", 0));
+
+        List<RuleTask> rerrortasks = new ArrayList<RuleTask>();
+        rerrortasks.add(new RuleTask("LOG", "rerrortasks", 0));
+
 		Rule tested = new Rule("rulename", 3, hosts, "recv-path", "send-path",
-            "arch-path", "work-path", tasks, tasks, tasks, tasks, tasks, tasks,
-            UpdatedInfo.TOSUBMIT);
+            "arch-path", "work-path", rpretasks, rposttasks, rerrortasks,
+            spretasks, sposttasks, serrortasks, UpdatedInfo.TOSUBMIT);
         DbRule dbRule = new DbRule(tested);
 
         String expected = "{" +
@@ -56,12 +75,12 @@ public class DbRuleTest {
             "\"WORKPATH\":\"/work-path\"," +
             "\"UPDATEDINFO\":3," +
             "\"HOSTIDS\":\"<hostids><hostid>sup1</hostid></hostids>\"," +
-            "\"RPRETASKS\":\"<tasks></tasks>\"," +
-            "\"RPOSTTASKS\":\"<tasks></tasks>\"," +
-            "\"SPRETASKS\":\"<tasks></tasks>\"," +
-            "\"SPOSTTASKS\":\"<tasks></tasks>\"," +
-            "\"RERRORTASKS\":\"<tasks></tasks>\"," +
-            "\"SERRORTASKS\":\"<tasks></tasks>\"" +
+            "\"SPRETASKS\":\"<tasks><task><type>LOG</type><path>spretasks</path><delay>0</delay></task></tasks>\"," +
+            "\"SERRORTASKS\":\"<tasks><task><type>LOG</type><path>serrortasks</path><delay>0</delay></task></tasks>\"," +
+            "\"RPRETASKS\":\"<tasks><task><type>LOG</type><path>rpretasks</path><delay>0</delay></task></tasks>\"," +
+            "\"RPOSTTASKS\":\"<tasks><task><type>LOG</type><path>rposttasks</path><delay>0</delay></task></tasks>\"," +
+            "\"RERRORTASKS\":\"<tasks><task><type>LOG</type><path>rerrortasks</path><delay>0</delay></task></tasks>\"," +
+            "\"SPOSTTASKS\":\"<tasks><task><type>LOG</type><path>sposttasks</path><delay>0</delay></task></tasks>\"" +
             "}";
 
 

--- a/WaarpR66/src/test/java/org/waarp/openr66/database/data/DbRuleTest.java
+++ b/WaarpR66/src/test/java/org/waarp/openr66/database/data/DbRuleTest.java
@@ -1,0 +1,71 @@
+/*
+ * This file is part of Waarp Project (named also Waarp or GG).
+ *
+ *  Copyright (c) 2019, Waarp SAS, and individual contributors by the @author
+ *  tags. See the COPYRIGHT.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ *  All Waarp Project is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * Waarp is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ * Waarp . If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.waarp.openr66.database.data;
+
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import org.junit.Test;
+import org.waarp.common.json.JsonHandler;
+import org.waarp.openr66.pojo.Rule;
+import org.waarp.openr66.pojo.RuleTask;
+import org.waarp.openr66.pojo.UpdatedInfo;
+
+import static org.junit.Assert.*;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class DbRuleTest {
+    @Test
+    public void testJsonSerialisation() {
+        List<String> hosts = Arrays.asList("sup1");
+        List<RuleTask> tasks = Arrays.asList();
+		Rule tested = new Rule("rulename", 3, hosts, "recv-path", "send-path",
+            "arch-path", "work-path", tasks, tasks, tasks, tasks, tasks, tasks,
+            UpdatedInfo.TOSUBMIT);
+        DbRule dbRule = new DbRule(tested);
+
+        String expected = "{" +
+            "\"@model\":\"DbRule\"," +
+            "\"IDRULE\":\"rulename\"," +
+            "\"MODETRANS\":3," +
+            "\"RECVPATH\":\"/recv-path\"," +
+            "\"SENDPATH\":\"/send-path\"," +
+            "\"ARCHIVEPATH\":\"/arch-path\"," +
+            "\"WORKPATH\":\"/work-path\"," +
+            "\"UPDATEDINFO\":3," +
+            "\"HOSTIDS\":\"<hostids><hostid>sup1</hostid></hostids>\"," +
+            "\"RPRETASKS\":\"<tasks></tasks>\"," +
+            "\"RPOSTTASKS\":\"<tasks></tasks>\"," +
+            "\"SPRETASKS\":\"<tasks></tasks>\"," +
+            "\"SPOSTTASKS\":\"<tasks></tasks>\"," +
+            "\"RERRORTASKS\":\"<tasks></tasks>\"," +
+            "\"SERRORTASKS\":\"<tasks></tasks>\"" +
+            "}";
+
+
+        ObjectNode asJson = dbRule.getJson();
+        String got = JsonHandler.writeAsString(asJson);
+
+        assertEquals(expected, got);
+    }
+}

--- a/WaarpR66/src/test/java/org/waarp/openr66/database/data/DbRuleTest.java
+++ b/WaarpR66/src/test/java/org/waarp/openr66/database/data/DbRuleTest.java
@@ -23,6 +23,7 @@ package org.waarp.openr66.database.data;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.waarp.common.json.JsonHandler;
 import org.waarp.openr66.pojo.Rule;
@@ -36,6 +37,7 @@ import java.util.List;
 
 public class DbRuleTest {
     @Test
+    @Ignore
     public void testJsonSerialisation() {
         List<String> hosts = Arrays.asList("sup1");
         List<RuleTask> tasks = Arrays.asList();

--- a/WaarpR66/src/test/java/org/waarp/openr66/database/data/DbTaskRunnerTest.java
+++ b/WaarpR66/src/test/java/org/waarp/openr66/database/data/DbTaskRunnerTest.java
@@ -1,0 +1,81 @@
+/*
+ * This file is part of Waarp Project (named also Waarp or GG).
+ *
+ *  Copyright (c) 2019, Waarp SAS, and individual contributors by the @author
+ *  tags. See the COPYRIGHT.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ *  All Waarp Project is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * Waarp is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ * Waarp . If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.waarp.openr66.database.data;
+
+import java.sql.Timestamp;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import org.junit.Test;
+import org.waarp.common.json.JsonHandler;
+import org.waarp.openr66.context.ErrorCode;
+import org.waarp.openr66.pojo.Transfer;
+import org.waarp.openr66.pojo.UpdatedInfo;
+
+import static org.junit.Assert.*;
+
+public class DbTaskRunnerTest {
+    @Test
+    public void testJsonSerialisation() {
+        Transfer transfer = new Transfer(12345L, "myrule", 2, "myfile.dat",
+                "myoriginalfile.dat", "myfileinfo", true, 42, false,
+                "me", "me", "other", "my-transfer-info",
+                Transfer.TASKSTEP.POSTTASK, Transfer.TASKSTEP.TRANSFERTASK, 53,
+                ErrorCode.MD5Error, ErrorCode.Unimplemented, 72,
+                new Timestamp(1581092031000L),
+                new Timestamp(1581092131000L), UpdatedInfo.RUNNING);
+        DbTaskRunner dbTransfer = new DbTaskRunner(transfer);
+
+        String expected = "{" +
+            "\"@model\":\"DbTaskRunner\"," +
+            "\"SPECIALID\":12345," +
+            "\"RETRIEVEMODE\":false," +
+            "\"IDRULE\":\"myrule\"," +
+            "\"MODETRANS\":2," +
+            "\"FILENAME\":\"myfile.dat\"," +
+            "\"ORIGINALNAME\":\"myoriginalfile.dat\"," +
+            "\"FILEINFO\":\"myfileinfo\"," +
+            "\"ISMOVED\":true," +
+            "\"BLOCKSZ\":42," +
+            "\"OWNERREQ\":\"me\"," +
+            "\"REQUESTER\":\"me\"," +
+            "\"REQUESTED\":\"other\"," +
+            "\"TRANSFERINFO\":\"my-transfer-info\"," +
+            "\"GLOBALSTEP\":3," +
+            "\"GLOBALLASTSTEP\":2," +
+            "\"STEP\":53," +
+            "\"STEPSTATUS\":\"M  \"," +
+            "\"INFOSTATUS\":\"U  \"," +
+            "\"RANK\":72," +
+            "\"STARTTRANS\":1581092031000," +
+            "\"STOPTRANS\":1581092131000," +
+            "\"UPDATEDINFO\":5," +
+            "\"ORIGINALSIZE\":-1" +
+            "}";
+
+
+        ObjectNode asJson = dbTransfer.getJson();
+        String got = JsonHandler.writeAsString(asJson);
+
+        assertEquals(expected, got);
+    }
+}

--- a/WaarpR66/src/test/java/org/waarp/openr66/pojo/BusinessTest.java
+++ b/WaarpR66/src/test/java/org/waarp/openr66/pojo/BusinessTest.java
@@ -1,0 +1,28 @@
+package org.waarp.openr66.pojo;
+
+import org.junit.Test;
+
+import org.waarp.common.json.JsonHandler;
+
+import static org.junit.Assert.*;
+
+public class BusinessTest {
+
+	@Test
+	public void testJson() {
+		Business tested = new Business("Test", "business", "roles", "aliases", "others", UpdatedInfo.UNKNOWN);
+
+        String expected = "{" +
+            "\"HOSTID\":\"Test\"," +
+            "\"BUSINESS\":\"business\"," +
+            "\"ROLES\":\"roles\"," +
+            "\"ALIASES\":\"aliases\"," +
+            "\"OTHERS\":\"others\"," +
+            "\"UPDATEDINFO\":0" +
+            "}";
+
+		String got = JsonHandler.writeAsString(tested);
+		
+		assertEquals(expected, got);
+	}
+}

--- a/WaarpR66/src/test/java/org/waarp/openr66/pojo/HostTest.java
+++ b/WaarpR66/src/test/java/org/waarp/openr66/pojo/HostTest.java
@@ -1,0 +1,34 @@
+package org.waarp.openr66.pojo;
+
+import org.junit.Test;
+
+import org.waarp.common.json.JsonHandler;
+
+import static org.junit.Assert.*;
+
+public class HostTest {
+
+	@Test
+	public void testJson() {
+        byte[] rawbytes = { 0xA, 0x2 };
+        Host host = new Host("hostid", "127.0.0.1", 6666, rawbytes, false, true, true, true,
+                true, UpdatedInfo.UNKNOWN);
+
+        String expected = "{" +
+                "\"HOSTID\":\"hostid\"," +
+                "\"ADDRESS\":\"127.0.0.1\"," +
+                "\"PORT\":6666," +
+                "\"HOSTKEY\":\"CgI=\"," +
+                "\"ISSSL\":false," +
+                "\"ISCLIENT\":true," +
+                "\"ISPROXIFIED\":true," +
+                "\"ADMINROLE\":true," +
+                "\"ISACTIVE\":true," +
+                "\"UPDATEDINFO\":0" +
+            "}";
+
+		String got = JsonHandler.writeAsString(host);
+
+		assertEquals(expected, got);
+	}
+}

--- a/WaarpR66/src/test/java/org/waarp/openr66/pojo/LimitTest.java
+++ b/WaarpR66/src/test/java/org/waarp/openr66/pojo/LimitTest.java
@@ -1,0 +1,29 @@
+package org.waarp.openr66.pojo;
+
+import org.junit.Test;
+
+import org.waarp.common.json.JsonHandler;
+
+import static org.junit.Assert.*;
+
+public class LimitTest {
+
+	@Test
+	public void testJson() {
+		Limit limit = new Limit("hostid",10, 20, 30, 40, 50, UpdatedInfo.TOSUBMIT);
+
+        String expected = "{" +
+            "\"HOSTID\":\"hostid\"," +
+            "\"READGLOBALLIMIT\":20," +
+            "\"WRITEGLOBALLIMIT\":30," +
+            "\"READSESSIONLIMIT\":40," +
+            "\"WRITESESSIONLIMIT\":50," +
+            "\"DELAYLIMIT\":10," +
+            "\"UPDATEDINFO\":3" +
+            "}";
+
+		String got = JsonHandler.writeAsString(limit);
+
+		assertEquals(expected, got);
+	}
+}

--- a/WaarpR66/src/test/java/org/waarp/openr66/pojo/RuleTest.java
+++ b/WaarpR66/src/test/java/org/waarp/openr66/pojo/RuleTest.java
@@ -1,5 +1,6 @@
 package org.waarp.openr66.pojo;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import org.waarp.common.json.JsonHandler;
@@ -9,9 +10,13 @@ import static org.junit.Assert.*;
 import java.util.Arrays;
 import java.util.List;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
 public class RuleTest {
 
 	@Test
+    @Ignore
 	public void testJson() {
         List<String> hosts = Arrays.asList("sup1");
         List<RuleTask> tasks = Arrays.asList();

--- a/WaarpR66/src/test/java/org/waarp/openr66/pojo/RuleTest.java
+++ b/WaarpR66/src/test/java/org/waarp/openr66/pojo/RuleTest.java
@@ -1,28 +1,43 @@
 package org.waarp.openr66.pojo;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 import org.waarp.common.json.JsonHandler;
 
 import static org.junit.Assert.*;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.SerializationFeature;
 
 public class RuleTest {
 
 	@Test
-    @Ignore
 	public void testJson() {
         List<String> hosts = Arrays.asList("sup1");
-        List<RuleTask> tasks = Arrays.asList();
+
+        List<RuleTask> spretasks = new ArrayList<RuleTask>();
+        spretasks.add(new RuleTask("LOG", "spretasks", 0));
+
+        List<RuleTask> sposttasks = new ArrayList<RuleTask>();
+        sposttasks.add(new RuleTask("LOG", "sposttasks", 0));
+
+        List<RuleTask> serrortasks = new ArrayList<RuleTask>();
+        serrortasks.add(new RuleTask("LOG", "serrortasks", 0));
+
+        List<RuleTask> rpretasks = new ArrayList<RuleTask>();
+        rpretasks.add(new RuleTask("LOG", "rpretasks", 0));
+
+        List<RuleTask> rposttasks = new ArrayList<RuleTask>();
+        rposttasks.add(new RuleTask("LOG", "rposttasks", 0));
+
+        List<RuleTask> rerrortasks = new ArrayList<RuleTask>();
+        rerrortasks.add(new RuleTask("LOG", "rerrortasks", 0));
+
 		Rule tested = new Rule("rulename", 3, hosts, "recv-path", "send-path",
-            "arch-path", "work-path", tasks, tasks, tasks, tasks, tasks, tasks,
-            UpdatedInfo.TOSUBMIT);
+            "arch-path", "work-path", rpretasks, rposttasks, rerrortasks,
+            spretasks, sposttasks, serrortasks, UpdatedInfo.TOSUBMIT);
 
         String expected = "{" +
             "\"IDRULE\":\"rulename\"," +
@@ -33,12 +48,12 @@ public class RuleTest {
             "\"WORKPATH\":\"work-path\"," +
             "\"UPDATEDINFO\":3," +
             "\"HOSTIDS\":\"<hostids><hostid>sup1</hostid></hostids>\"," +
-            "\"RPRETASKS\":\"<tasks></tasks>\"," +
-            "\"RPOSTTASKS\":\"<tasks></tasks>\"," +
-            "\"SPRETASKS\":\"<tasks></tasks>\"," +
-            "\"SPOSTTASKS\":\"<tasks></tasks>\"," +
-            "\"RERRORTASKS\":\"<tasks></tasks>\"," +
-            "\"SERRORTASKS\":\"<tasks></tasks>\"" +
+            "\"SPRETASKS\":\"<tasks><task><type>LOG</type><path>spretasks</path><delay>0</delay></task></tasks>\"," +
+            "\"SERRORTASKS\":\"<tasks><task><type>LOG</type><path>serrortasks</path><delay>0</delay></task></tasks>\"," +
+            "\"RPRETASKS\":\"<tasks><task><type>LOG</type><path>rpretasks</path><delay>0</delay></task></tasks>\"," +
+            "\"RPOSTTASKS\":\"<tasks><task><type>LOG</type><path>rposttasks</path><delay>0</delay></task></tasks>\"," +
+            "\"RERRORTASKS\":\"<tasks><task><type>LOG</type><path>rerrortasks</path><delay>0</delay></task></tasks>\"," +
+            "\"SPOSTTASKS\":\"<tasks><task><type>LOG</type><path>sposttasks</path><delay>0</delay></task></tasks>\"" +
             "}";
 
 		String got = JsonHandler.writeAsString(tested);

--- a/WaarpR66/src/test/java/org/waarp/openr66/pojo/RuleTest.java
+++ b/WaarpR66/src/test/java/org/waarp/openr66/pojo/RuleTest.java
@@ -1,0 +1,43 @@
+package org.waarp.openr66.pojo;
+
+import org.junit.Test;
+
+import org.waarp.common.json.JsonHandler;
+
+import static org.junit.Assert.*;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class RuleTest {
+
+	@Test
+	public void testJson() {
+        List<String> hosts = Arrays.asList("sup1");
+        List<RuleTask> tasks = Arrays.asList();
+		Rule tested = new Rule("rulename", 3, hosts, "recv-path", "send-path",
+            "arch-path", "work-path", tasks, tasks, tasks, tasks, tasks, tasks,
+            UpdatedInfo.TOSUBMIT);
+
+        String expected = "{" +
+            "\"IDRULE\":\"rulename\"," +
+            "\"MODETRANS\":3," +
+            "\"RECVPATH\":\"recv-path\"," +
+            "\"SENDPATH\":\"send-path\"," +
+            "\"ARCHIVEPATH\":\"arch-path\"," +
+            "\"WORKPATH\":\"work-path\"," +
+            "\"UPDATEDINFO\":3," +
+            "\"HOSTIDS\":\"<hostids><hostid>sup1</hostid></hostids>\"," +
+            "\"RPRETASKS\":\"<tasks></tasks>\"," +
+            "\"RPOSTTASKS\":\"<tasks></tasks>\"," +
+            "\"SPRETASKS\":\"<tasks></tasks>\"," +
+            "\"SPOSTTASKS\":\"<tasks></tasks>\"," +
+            "\"RERRORTASKS\":\"<tasks></tasks>\"," +
+            "\"SERRORTASKS\":\"<tasks></tasks>\"" +
+            "}";
+
+		String got = JsonHandler.writeAsString(tested);
+
+		assertEquals(expected, got);
+	}
+}

--- a/WaarpR66/src/test/java/org/waarp/openr66/pojo/TransferTest.java
+++ b/WaarpR66/src/test/java/org/waarp/openr66/pojo/TransferTest.java
@@ -1,0 +1,99 @@
+/*
+ * This file is part of Waarp Project (named also Waarp or GG).
+ *
+ *  Copyright (c) 2019, Waarp SAS, and individual contributors by the @author
+ *  tags. See the COPYRIGHT.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ *  All Waarp Project is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * Waarp is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ * Waarp . If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.waarp.openr66.pojo;
+
+import java.sql.Timestamp;
+
+import org.junit.Test;
+import org.waarp.common.json.JsonHandler;
+import org.waarp.openr66.context.ErrorCode;
+
+import static org.junit.Assert.*;
+
+public class TransferTest {
+    @Test
+    public void testJsonSerialisation() {
+        Transfer transfer = new Transfer(12345, "myrule", 2, "myfile.dat",
+                "myoriginalfile.dat", "myfileinfo", true, 42, false,
+                "me", "me", "other", "my-transfer-info",
+                Transfer.TASKSTEP.POSTTASK, Transfer.TASKSTEP.TRANSFERTASK, 53,
+                ErrorCode.MD5Error, ErrorCode.Unimplemented, 72,
+                new Timestamp(1581092031000L),
+                new Timestamp(1581092131000L), UpdatedInfo.RUNNING);
+
+        //String expected = "{" +
+        //    "\"@model\":\"DbTaskRunner\"," +
+        //    "\"BLOCKSZ\":42," +
+        //    "\"FILEINFO\":\"myfileinfo\"," +
+        //    "\"FILENAME\":\"myfile.dat\"," +
+        //    "\"GLOBALLASTSTEP\":2," +
+        //    "\"GLOBALSTEP\":3," +
+        //    "\"IDRULE\":\"myrule\"," +
+        //    "\"INFOSTATUS\":\"U  \"," +
+        //    "\"ISMOVED\":true," +
+        //    "\"MODETRANS\":2," +
+        //    "\"ORIGINALNAME\":\"myoriginalfile.dat\"," +
+        //    "\"ORIGINALSIZE\":-1," +
+        //    "\"OWNERREQ\":\"me\"," +
+        //    "\"RANK\":72," +
+        //    "\"REQUESTED\":\"other\"," +
+        //    "\"REQUESTER\":\"me\"," +
+        //    "\"RETRIEVEMODE\":false," +
+        //    "\"SPECIALID\":12345," +
+        //    "\"STARTTRANS\":1581092031000," +
+        //    "\"STEP\":53," +
+        //    "\"STEPSTATUS\":\"M  \"," +
+        //    "\"STOPTRANS\":1581092131000," +
+        //    "\"TRANSFERINFO\":\"my-transfer-info\"," +
+        //    "\"UPDATEDINFO\":5" +
+        //    "}";
+
+        String expected = "{" +
+            "\"SPECIALID\":12345," +
+            "\"RETRIEVEMODE\":false," +
+            "\"IDRULE\":\"myrule\"," +
+            "\"MODETRANS\":2," +
+            "\"FILENAME\":\"myfile.dat\"," +
+            "\"ORIGINALNAME\":\"myoriginalfile.dat\"," +
+            "\"FILEINFO\":\"myfileinfo\"," +
+            "\"ISMOVED\":true," +
+            "\"BLOCKSZ\":42," +
+            "\"OWNERREQ\":\"me\"," +
+            "\"REQUESTER\":\"me\"," +
+            "\"REQUESTED\":\"other\"," +
+            "\"TRANSFERINFO\":\"my-transfer-info\"," +
+            "\"GLOBALSTEP\":3," +
+            "\"GLOBALLASTSTEP\":2," +
+            "\"STEP\":53," +
+            "\"STEPSTATUS\":\"M  \"," +
+            "\"INFOSTATUS\":\"U  \"," +
+            "\"RANK\":72," +
+            "\"STARTTRANS\":1581092031000," +
+            "\"STOPTRANS\":1581092131000," +
+            "\"UPDATEDINFO\":5" +
+            "}";
+
+
+        String got = JsonHandler.writeAsString(transfer);
+
+        assertEquals(expected, got);
+    }
+}

--- a/doc/waarp-r66/source/changes.rst
+++ b/doc/waarp-r66/source/changes.rst
@@ -8,8 +8,8 @@ Waarp R66 Next (Non publiée)
 Correctifs
 ==========
 
-- [[#9](https://github.com/waarp/Waarp-All/pull/9)] Corrige une régression sur
-  l'API REST v1 introduite dans la version 3.2.0
+- [`#9 <https://github.com/waarp/Waarp-All/pull/9>`__] Corrige une régression
+  sur l'API REST v1 introduite dans la version 3.2.0
 
 
 Waarp R66 3.3.0 (2020-01-18)

--- a/doc/waarp-r66/source/changes.rst
+++ b/doc/waarp-r66/source/changes.rst
@@ -2,6 +2,15 @@
 Liste des changements
 #####################
 
+Waarp R66 Next (Non publiée)
+============================
+
+Correctifs
+==========
+
+- [[#9](https://github.com/waarp/Waarp-All/pull/9)] Corrige une régression sur
+  l'API REST v1 introduite dans la version 3.2.0
+
 
 Waarp R66 3.3.0 (2020-01-18)
 ============================


### PR DESCRIPTION
The rewrite of the database layer introduced a regression in the responses of REST v1 CRUD queries. The property names have changed, and in some cases, the values changed too.

The PR fixes this regression introduced in v3.2.0.