### PR TITLE
Regression host negative port

### DIFF
--- a/WaarpR66/src/main/java/org/waarp/openr66/pojo/Host.java
+++ b/WaarpR66/src/main/java/org/waarp/openr66/pojo/Host.java
@@ -99,15 +99,9 @@ public class Host {
     this.hostid = hostid;
     this.hostkey = hostkey;
     // Force client status if unvalid port
-    if (port < 1) {
-      this.address = DEFAULT_CLIENT_ADDRESS;
-      this.port = DEFAULT_CLIENT_PORT;
-      this.client = true;
-    } else {
-      this.address = address;
-      this.port = port;
-      this.client = client;
-    }
+    this.address = address;
+    this.port = port;
+    this.client = client;
     this.ssl = ssl;
     this.proxified = proxified;
     this.admin = admin;

--- a/WaarpR66/src/test/java/org/waarp/openr66/pojo/HostTest.java
+++ b/WaarpR66/src/test/java/org/waarp/openr66/pojo/HostTest.java
@@ -31,4 +31,13 @@ public class HostTest {
 
 		assertEquals(expected, got);
 	}
+
+	@Test
+	public void testNegativePort() {
+        byte[] rawbytes = { 0xA, 0x2 };
+        Host host = new Host("hostid", "127.0.0.1", -42, rawbytes, false, true, true, true,
+                true, UpdatedInfo.UNKNOWN);
+        
+        assertEquals(-42, host.getPort());
+    }
 }

--- a/doc/waarp-r66/source/changes.rst
+++ b/doc/waarp-r66/source/changes.rst
@@ -10,6 +10,9 @@ Correctifs
 
 - [`#9 <https://github.com/waarp/Waarp-All/pull/9>`__] Corrige une régression
   sur l'API REST v1 introduite dans la version 3.2.0
+- [`#10 <https://github.com/waarp/Waarp-All/pull/10>`__] Corrige une régression
+  qui empêche les ports négatifs pour les partenaires introduite dans la version
+  3.2.0
 
 
 Waarp R66 3.3.0 (2020-01-18)


### PR DESCRIPTION
v3.2.0 prevents hosts to have a negative port, which is a condition needed for REST API clients.

The PR fixes this regression

(I will rebase it on v3.3 when #9 is merged)