### PR TITLE
Fix missing password and SonarQube dependency

### DIFF
--- a/WaarpGatewayFtp/pom.xml
+++ b/WaarpGatewayFtp/pom.xml
@@ -57,6 +57,10 @@
     </dependency>
     <dependency>
       <groupId>Waarp</groupId>
+      <artifactId>WaarpPassword</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>Waarp</groupId>
       <artifactId>WaarpSnmp</artifactId>
     </dependency>
     <dependency>

--- a/WaarpPassword/pom.xml
+++ b/WaarpPassword/pom.xml
@@ -70,6 +70,10 @@
           <reuseForks>true</reuseForks>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/WaarpProxyR66/pom.xml
+++ b/WaarpProxyR66/pom.xml
@@ -48,6 +48,10 @@
     </dependency>
     <dependency>
       <groupId>Waarp</groupId>
+      <artifactId>WaarpPassword</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>Waarp</groupId>
       <artifactId>WaarpR66</artifactId>
     </dependency>
     <dependency>

--- a/WaarpR66/pom.xml
+++ b/WaarpR66/pom.xml
@@ -82,6 +82,10 @@
     </dependency>
     <dependency>
       <groupId>Waarp</groupId>
+      <artifactId>WaarpPassword</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>Waarp</groupId>
       <artifactId>WaarpThrift</artifactId>
     </dependency>
     <dependency>

--- a/doc/waarp-r66/source/changes.rst
+++ b/doc/waarp-r66/source/changes.rst
@@ -10,7 +10,8 @@ Correctifs
 
 - [`#13 <https://github.com/waarp/Waarp-All/pull/13>`__] Corrige l'oubli du
   module WaarpPassword dans les autres modules dans les packages
-  `jar-with-dependencies` et en crée un pour WaarpPassword
+  `jar-with-dependencies` et en crée un pour WaarpPassword ;
+  Met à jour les dépendances pour SonarQube (usage interne)
 - [`#9 <https://github.com/waarp/Waarp-All/pull/9>`__] Corrige une régression
   sur l'API REST v1 introduite dans la version 3.2.0
 - [`#10 <https://github.com/waarp/Waarp-All/pull/10>`__] Corrige une régression

--- a/doc/waarp-r66/source/changes.rst
+++ b/doc/waarp-r66/source/changes.rst
@@ -8,6 +8,9 @@ Waarp R66 Next (Non publiée)
 Correctifs
 ==========
 
+- [`#13 <https://github.com/waarp/Waarp-All/pull/13>`__] Corrige l'oubli du
+  module WaarpPassword dans les autres modules dans les packages
+  `jar-with-dependencies` et en crée un pour WaarpPassword
 - [`#9 <https://github.com/waarp/Waarp-All/pull/9>`__] Corrige une régression
   sur l'API REST v1 introduite dans la version 3.2.0
 - [`#10 <https://github.com/waarp/Waarp-All/pull/10>`__] Corrige une régression

--- a/pom.xml
+++ b/pom.xml
@@ -194,8 +194,8 @@
 
     <!-- Sonar -->
     <sonar.core.codeCoveragePlugin>jacoco</sonar.core.codeCoveragePlugin>
-    <jacoco-maven-plugin.version>0.8.4</jacoco-maven-plugin.version>
-    <sonar-maven-plugin.version>3.6.1.1688</sonar-maven-plugin.version>
+    <jacoco-maven-plugin.version>0.8.5</jacoco-maven-plugin.version>
+    <sonar-maven-plugin.version>3.7.0.1746</sonar-maven-plugin.version>
     <sonar.sources>src/main/java</sonar.sources>
     <sonar.tests>src/test/java</sonar.tests>
     <sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
@@ -1251,6 +1251,44 @@
             <configuration>
               <updateReleaseInfo>true</updateReleaseInfo>
             </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>coverage</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>prepare-agent</id>
+                <goals>
+                  <goal>prepare-agent</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>report</id>
+                <goals>
+                  <goal>report</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>report</id>
+                <goals>
+                  <goal>report-aggregate</goal>
+                </goals>
+                <phase>verify</phase>
+              </execution>
+            </executions>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
In various modules, WaarpPassword was missing in the "all dependencies" jar.
Moreover, WaarpPassword has no standalone jar (all dependencies) (see issue #11 )

Fix Pom for SonarQube (internal usage) (mvn -Pcoverage clean verify sonar:sonar)
 - Note however a well known regression due to SonarQube itself in global result (some % disapears due to a known bug)

