### PR TITLE
Fix issue #19 on missing DbRule for DbTaskRunner

### DIFF
--- a/WaarpR66/src/main/java/org/waarp/openr66/dao/AbstractDAO.java
+++ b/WaarpR66/src/main/java/org/waarp/openr66/dao/AbstractDAO.java
@@ -96,7 +96,7 @@ public interface AbstractDAO<E> extends Cloneable {
   /**
    * Remove the specified object from the persistance layer
    *
-   * @param object object to insert
+   * @param object object to delete
    *
    * @throws DAOConnectionException If a data access error occurs
    * @throws DAONoDataException if no data are available

--- a/WaarpR66/src/main/java/org/waarp/openr66/protocol/http/adminssl/HttpSslHandler.java
+++ b/WaarpR66/src/main/java/org/waarp/openr66/protocol/http/adminssl/HttpSslHandler.java
@@ -510,7 +510,7 @@ public class HttpSslHandler
             try {
               i++;
               final DbTaskRunner taskRunner =
-                  DbTaskRunner.getFromStatement(preparedStatement);
+                  DbTaskRunner.getFromStatementNoRule(preparedStatement);
               if (isNotReload) {
                 final long specid = taskRunner.getSpecialId();
                 if (idstart == null || idstart > specid) {
@@ -641,7 +641,7 @@ public class HttpSslHandler
             try {
               i++;
               final DbTaskRunner taskRunner =
-                  DbTaskRunner.getFromStatement(preparedStatement);
+                  DbTaskRunner.getFromStatementNoRule(preparedStatement);
               if (isNotReload) {
                 final long specid = taskRunner.getSpecialId();
                 if (idstart == null || idstart > specid) {

--- a/WaarpR66/src/main/java/org/waarp/openr66/protocol/networkhandler/packet/NetworkPacket.java
+++ b/WaarpR66/src/main/java/org/waarp/openr66/protocol/networkhandler/packet/NetworkPacket.java
@@ -124,10 +124,10 @@ public class NetworkPacket {
   @Override
   public String toString() {
     return "RId: " + remoteId + " LId: " + localId + " Code: " + code +
-           " Length: " + buffer.readableBytes() +
+           " Length: " + buffer != null ? (buffer.readableBytes() +
            (code == LocalPacketFactory.REQUESTPACKET? buffer
                .toString(buffer.readerIndex(), buffer.readableBytes(),
-                         Charsets.UTF_8) : "");
+                         Charsets.UTF_8) : "")) : "no buffer";
   }
 
   public void clear() {

--- a/WaarpR66/src/test/java/org/waarp/openr66/protocol/junit/TestAbstract.java
+++ b/WaarpR66/src/test/java/org/waarp/openr66/protocol/junit/TestAbstract.java
@@ -25,6 +25,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.openqa.selenium.Platform;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.logging.LogType;
+import org.openqa.selenium.logging.LoggingPreferences;
 import org.openqa.selenium.phantomjs.PhantomJSDriver;
 import org.openqa.selenium.phantomjs.PhantomJSDriverService;
 import org.openqa.selenium.remote.CapabilityType;
@@ -61,6 +63,7 @@ import java.io.FileFilter;
 import java.net.SocketAddress;
 import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
 
 import static org.junit.Assert.*;
 
@@ -240,17 +243,31 @@ public abstract class TestAbstract extends TestAbstractMinimal {
     desiredCapabilities.setCapability(CapabilityType.TAKES_SCREENSHOT, false);
     desiredCapabilities
         .setCapability(CapabilityType.ENABLE_PROFILING_CAPABILITY, false);
+    LoggingPreferences logPrefs = new LoggingPreferences();
+    logPrefs.enable(LogType.BROWSER, Level.OFF);
+    logPrefs.enable(LogType.CLIENT, Level.OFF);
+    logPrefs.enable(LogType.DRIVER, Level.OFF);
+    logPrefs.enable(LogType.PERFORMANCE, Level.OFF);
+    logPrefs.enable(LogType.PROFILER, Level.OFF);
+    logPrefs.enable(LogType.SERVER, Level.OFF);
+    desiredCapabilities
+        .setCapability(CapabilityType.LOGGING_PREFS, logPrefs);
+    desiredCapabilities
+        .setCapability(CapabilityType.TAKES_SCREENSHOT, false);
     desiredCapabilities.setCapability(CapabilityType.HAS_NATIVE_EVENTS, true);
-
+    desiredCapabilities.setCapability(PhantomJSDriverService.PHANTOMJS_GHOSTDRIVER_CLI_ARGS, "--webdriver-loglevel=NONE");
     desiredCapabilities.setJavascriptEnabled(true);
 
     ArrayList<String> cliArgs = new ArrayList<String>();
     cliArgs.add("--web-security=true");
     cliArgs.add("--ignore-ssl-errors=true");
+    cliArgs.add("--webdriver-loglevel=NONE");
     desiredCapabilities
         .setCapability(PhantomJSDriverService.PHANTOMJS_CLI_ARGS, cliArgs);
 
-    return new PhantomJSDriver(desiredCapabilities);
+    PhantomJSDriver phantomJSDriver = new PhantomJSDriver(desiredCapabilities);
+    phantomJSDriver.setLogLevel(Level.OFF);
+    return phantomJSDriver;
   }
 
   public static void finalizeDriver() throws InterruptedException {

--- a/doc/waarp-r66/source/changes.rst
+++ b/doc/waarp-r66/source/changes.rst
@@ -7,6 +7,18 @@ La procédure de mise à jour est disponible ici: :any:`upgrade`
 Non publié
 ==========
 
+Waarp R66 3.3.2 (2020-04-29)
+============================
+
+Correctifs
+==========
+
+- [`#20 <https://github.com/waarp/Waarp-All/pull/20>`__] Corrige l'affichage
+  d'un transfert dont la règle n'existe plus dans l'interface
+  d'administration Web Waarp OpenR66
+  (issue [`#19 <https://github.com/waarp/Waarp-All/issues/19>`__])
+- Corrige les dépendances externes
+
 Waarp R66 3.3.2 (2020-04-21)
 ============================
 


### PR DESCRIPTION
When a DbRule is missing (deleted), one DbTaskRunner sibling it cannot be shown
in Https Admin interface. As this is obviously an issue to have such DbTaskRunner
with such missing DbRule, we fix however the printing such that this DbTaskRunner
is shown with its DbRule in RED color.

Note however that all tasks that need this Rule to exist continue to return an
error (such as cancel, stop, restart).

Issue #19 is therefore fixed.