### PR TITLE
Server start message is written as an error on stderr

### DIFF
--- a/WaarpR66/src/main/java/org/waarp/openr66/server/R66Server.java
+++ b/WaarpR66/src/main/java/org/waarp/openr66/server/R66Server.java
@@ -54,11 +54,11 @@ public class R66Server {
     try {
       WaarpShutdownHook.registerMain(R66Server.class, args);
       if (initialize(args[0])) {
-        logger.warn(Messages.getString("R66Server.ServerStart") +
+        logger.info(Messages.getString("R66Server.ServerStart") +
                     Configuration.configuration.getHostId() + " : "
                     //$NON-NLS-1$
                     + Configuration.configuration);
-        SysErrLogger.FAKE_LOGGER.syserr(
+        SysErrLogger.FAKE_LOGGER.sysout(
             Messages.getString("R66Server.ServerStart") +
             Configuration.configuration.getHostId()); //$NON-NLS-1$
       } else {

--- a/doc/waarp-r66/source/changes.rst
+++ b/doc/waarp-r66/source/changes.rst
@@ -7,11 +7,20 @@ La procédure de mise à jour est disponible ici: :any:`upgrade`
 Non publié
 ==========
 
+Correctifs
+----------
+
+- Le succès du lancement du serveur n'est plus ecrit sur la sortie standard avec
+  "ERROR"
+- Le succès du lancement du serveur est loggué en niveau INFO plustôt qu'en
+  WARNING
+
+
 Waarp R66 3.3.2 (2020-04-21)
 ============================
 
 Correctifs
-==========
+----------
 
 - Corrige les tests Rest V1
 - Corrige des méthodes manquantes dans le module WaarpHttp
@@ -31,7 +40,7 @@ Waarp R66 3.3.1 (2020-02-17)
 ============================
 
 Correctifs
-==========
+----------
 
 - [`#13 <https://github.com/waarp/Waarp-All/pull/13>`__] Corrige l'oubli du
   module WaarpPassword dans les autres modules dans les packages


### PR DESCRIPTION
It is not the usage to print success messages on stderr, and it is misleading
that it is prefixed with "ERROR". I moved it to stdout.

The same goes for the logs where the success message is written as a warning. I
moved it to INFO.