### PR TITLE
Fix issue #22 for Path in Rule under Windows OS

### DIFF
--- a/WaarpR66/src/main/java/org/waarp/openr66/pojo/Rule.java
+++ b/WaarpR66/src/main/java/org/waarp/openr66/pojo/Rule.java
@@ -180,10 +180,10 @@ public class Rule {
     this.name = name;
     this.mode = mode;
     this.hostids = hostids;
-    this.recvPath = recvPath;
-    this.sendPath = sendPath;
-    this.archivePath = archivePath;
-    this.workPath = workPath;
+    this.recvPath = checkPath(recvPath);
+    this.sendPath = checkPath(sendPath);
+    this.archivePath = checkPath(archivePath);
+    this.workPath = checkPath(workPath);
     rPreTasks = rPre;
     rPostTasks = rPost;
     rErrorTasks = rError;
@@ -283,12 +283,19 @@ public class Rule {
     this.hostids = hostids;
   }
 
+  private String checkPath(String path) {
+    if (path == null || path.trim().isEmpty()) {
+      return "";
+    }
+    return path.replace("//", "/").replace("\\\\", "\\");
+  }
+
   public String getRecvPath() {
     return recvPath;
   }
 
   public void setRecvPath(String recvPath) {
-    this.recvPath = recvPath;
+    this.recvPath = checkPath(recvPath);
   }
 
   public String getSendPath() {
@@ -296,7 +303,7 @@ public class Rule {
   }
 
   public void setSendPath(String sendPath) {
-    this.sendPath = sendPath;
+    this.sendPath = checkPath(sendPath);
   }
 
   public String getArchivePath() {
@@ -304,7 +311,7 @@ public class Rule {
   }
 
   public void setArchivePath(String archivePath) {
-    this.archivePath = archivePath;
+    this.archivePath = checkPath(archivePath);
   }
 
   public String getWorkPath() {
@@ -312,7 +319,7 @@ public class Rule {
   }
 
   public void setWorkPath(String workPath) {
-    this.workPath = workPath;
+    this.workPath = checkPath(workPath);
   }
 
   @JsonIgnore

--- a/doc/waarp-r66/source/changes.rst
+++ b/doc/waarp-r66/source/changes.rst
@@ -15,8 +15,12 @@ Correctifs
 
 - [`#20 <https://github.com/waarp/Waarp-All/pull/20>`__] Corrige l'affichage
   d'un transfert dont la règle n'existe plus dans l'interface
-  d'administration Web Waarp OpenR66
+  d'administration Web Waarp OpenR66 et empêche l'effacement d'une règle
+  tant qu'il existe au moins un transfert qui l'utilise dans sa définition.
   (issue [`#19 <https://github.com/waarp/Waarp-All/issues/19>`__])
+- [`#23 <https://github.com/waarp/Waarp-All/pull/23>`__] Corrige la prise
+  en compte d'un chemin sous Windows avec \ qui se double en \\
+  (issue [`#22 <https://github.com/waarp/Waarp-All/issues/22>`__])
 - Corrige les dépendances externes
 
 Waarp R66 3.3.2 (2020-04-21)


### PR DESCRIPTION
When a Path contains the char \, this was replaced by a double \\ in the
Web interface, and adding a \ each time it was updated.

This fix this issue (even if it does not prevent the correct behavior but
just the printing that is unpleasant).
