### PR TITLE
Issue #24 GW FTP stops immediately after startup

### DIFF
--- a/WaarpFtp/core/src/main/java/org/waarp/ftp/core/config/FtpInternalConfiguration.java
+++ b/WaarpFtp/core/src/main/java/org/waarp/ftp/core/config/FtpInternalConfiguration.java
@@ -151,7 +151,7 @@ public class FtpInternalConfiguration {
    * Scheduler for TrafficCounter
    */
   private final ScheduledExecutorService executorService = Executors
-      .newScheduledThreadPool(2, new WaarpThreadFactory("TimerTrafficFtp"));
+      .newScheduledThreadPool(2, new WaarpThreadFactory("TimerTrafficFtp", false));
 
   /**
    * Global TrafficCounter (set from global configuration)

--- a/WaarpGatewayFtp/src/test/java/org/waarp/gateway/ftp/client/FtpClientTest.java
+++ b/WaarpGatewayFtp/src/test/java/org/waarp/gateway/ftp/client/FtpClientTest.java
@@ -28,8 +28,11 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.Platform;
 import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.logging.LogType;
+import org.openqa.selenium.logging.LoggingPreferences;
 import org.openqa.selenium.phantomjs.PhantomJSDriver;
 import org.openqa.selenium.phantomjs.PhantomJSDriverService;
 import org.openqa.selenium.remote.CapabilityType;
@@ -340,26 +343,40 @@ public class FtpClientTest {
   }
 
   private static WebDriver createPhantomJSDriver() {
-    DesiredCapabilities desiredCapabilities = DesiredCapabilities.phantomjs();
+	  DesiredCapabilities desiredCapabilities =
+		        new DesiredCapabilities("phantomjs", "", Platform.ANY);
     desiredCapabilities.setCapability(
         PhantomJSDriverService.PHANTOMJS_EXECUTABLE_PATH_PROPERTY,
         System.getProperty("phantomjs.binary.path"));
     desiredCapabilities
         .setCapability(CapabilityType.ELEMENT_SCROLL_BEHAVIOR, true);
-    desiredCapabilities.setCapability(CapabilityType.TAKES_SCREENSHOT, true);
+    desiredCapabilities.setCapability(CapabilityType.TAKES_SCREENSHOT, false);
     desiredCapabilities
         .setCapability(CapabilityType.ENABLE_PROFILING_CAPABILITY, true);
+    LoggingPreferences logPrefs = new LoggingPreferences();
+    logPrefs.enable(LogType.BROWSER, java.util.logging.Level.OFF);
+    logPrefs.enable(LogType.CLIENT, java.util.logging.Level.OFF);
+    logPrefs.enable(LogType.DRIVER, java.util.logging.Level.OFF);
+    logPrefs.enable(LogType.PERFORMANCE, java.util.logging.Level.OFF);
+    logPrefs.enable(LogType.PROFILER, java.util.logging.Level.OFF);
+    logPrefs.enable(LogType.SERVER, java.util.logging.Level.OFF);
+    desiredCapabilities
+        .setCapability(CapabilityType.LOGGING_PREFS, logPrefs);
     desiredCapabilities.setCapability(CapabilityType.HAS_NATIVE_EVENTS, true);
+    desiredCapabilities.setCapability(PhantomJSDriverService.PHANTOMJS_GHOSTDRIVER_CLI_ARGS, "--webdriver-loglevel=NONE");
 
     desiredCapabilities.setJavascriptEnabled(true);
 
     ArrayList<String> cliArgs = new ArrayList<String>();
     cliArgs.add("--web-security=true");
     cliArgs.add("--ignore-ssl-errors=true");
+    cliArgs.add("--webdriver-loglevel=NONE");
     desiredCapabilities
         .setCapability(PhantomJSDriverService.PHANTOMJS_CLI_ARGS, cliArgs);
 
-    return new PhantomJSDriver(desiredCapabilities);
+    PhantomJSDriver phantomJSDriver = new PhantomJSDriver(desiredCapabilities);
+    phantomJSDriver.setLogLevel(java.util.logging.Level.OFF);
+    return phantomJSDriver;
   }
 
   public static void finalizeDriver() throws InterruptedException {

--- a/WaarpGatewayFtp/src/test/java/org/waarp/gateway/ftp/client/ShutdownTestClient.java
+++ b/WaarpGatewayFtp/src/test/java/org/waarp/gateway/ftp/client/ShutdownTestClient.java
@@ -1,0 +1,59 @@
+package org.waarp.gateway.ftp.client;
+
+import java.io.File;
+
+import org.waarp.common.file.filesystembased.FilesystemBasedFileParameterImpl;
+import org.waarp.gateway.ftp.ExecGatewayFtpServer;
+import org.waarp.gateway.ftp.client.transaction.Ftp4JClientTransactionTest;
+import org.waarp.gateway.ftp.config.FileBasedConfiguration;
+import org.waarp.gateway.ftp.control.ExecBusinessHandler;
+import org.waarp.gateway.ftp.data.FileSystemBasedDataBusinessHandler;
+import org.waarp.gateway.ftp.database.DbConstantFtp;
+
+public class ShutdownTestClient {
+
+  public ShutdownTestClient() {
+    // TODO Auto-generated constructor stub
+  }
+
+  public static void main(String[] args) throws Exception {
+    if (args.length == 0) {
+      System.err.println("No argument: configuration file missing");
+      System.exit(3);
+    }
+    File file = new File(args[0]);
+    final FileBasedConfiguration configuration =
+      new FileBasedConfiguration(ExecGatewayFtpServer.class,
+        ExecBusinessHandler.class, FileSystemBasedDataBusinessHandler.class,
+        new FilesystemBasedFileParameterImpl());
+    try {
+      if (!configuration.setConfigurationServerFromXml(file.getAbsolutePath())) {
+        System.err.println("Bad main configuration");
+        System.exit(1);
+      }
+	} finally {
+      if (DbConstantFtp.gatewayAdmin != null) {
+        DbConstantFtp.gatewayAdmin.close();
+      }
+    }
+    System.err.println("Will start server");
+    String key = configuration.getCryptoKey().decryptHexInString("c5f4876737cf351a");
+    final Ftp4JClientTransactionTest client =
+            new Ftp4JClientTransactionTest("127.0.0.1", 2021, "fredo", key, "a", 0);
+    if (!client.connect()) {
+      System.err.println("Cant connect");
+      System.exit(2);
+      return;
+    }
+    try {
+      final String[] results =
+          client.executeSiteCommand("internalshutdown pwdhttp");
+      System.err.print("SHUTDOWN: ");
+      for (final String string : results) {
+        System.err.println(string);
+      }
+    } finally {
+      client.disconnect();
+    }
+  }
+}

--- a/WaarpGatewayFtp/src/test/resources/Gg-FTP-minimal.xml
+++ b/WaarpGatewayFtp/src/test/resources/Gg-FTP-minimal.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ This file is part of Waarp Project (named also Waarp or GG).
+  ~
+  ~  Copyright (c) 2019, Waarp SAS, and individual contributors by the @author
+  ~  tags. See the COPYRIGHT.txt in the distribution for a full listing of
+  ~ individual contributors.
+  ~
+  ~  All Waarp Project is free software: you can redistribute it and/or
+  ~ modify it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or (at your
+  ~ option) any later version.
+  ~
+  ~ Waarp is distributed in the hope that it will be useful, but WITHOUT ANY
+  ~ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+  ~ A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+  ~
+  ~  You should have received a copy of the GNU General Public License along with
+  ~ Waarp . If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<config xmlns:x0="http://www.w3.org/2001/XMLSchema">
+    <comment>Let you write what you want here</comment>
+    <identity>
+        <hostid>myserver</hostid>
+        <cryptokey>src/test/resources/certs/test-key.des</cryptokey>
+        <authentfile>src/test/resources/Gg-authent.xml</authentfile>
+    </identity>
+    <server>
+        <uselocalexec>False</uselocalexec>
+        <serveradmin>monadmin</serveradmin>
+        <serverpasswd>c5f4876737cf351a</serverpasswd>
+        <usehttpcomp>True</usehttpcomp>
+        <httpadmin>src/main/admin</httpadmin>
+        <admkeypath>src/test/resources/certs/testsslnocert.jks</admkeypath>
+        <admkeystorepass>testsslnocert</admkeystorepass>
+        <admkeypass>testalias</admkeypass>
+    </server>
+    <network>
+        <serverport>2021</serverport>
+        <portmin>10000</portmin>
+        <portmax>30000</portmax>
+        <serverhttpsport>8067</serverhttpsport>
+    </network>
+    <exec>
+        <retrievecmd>EXECUTE echo</retrievecmd>
+        <storecmd>EXECUTE echo</storecmd>
+    </exec>
+    <directory>
+        <serverhome>/tmp/FTP</serverhome>
+    </directory>
+    <limit>
+        <deleteonabort>True</deleteonabort>
+        <sessionlimit>0</sessionlimit>
+        <globallimit>0</globallimit>
+        <delaylimit>1000</delaylimit>
+        <serverthread>4</serverthread>
+        <clientthread>40</clientthread>
+        <timeoutcon>1000</timeoutcon>
+        <usenio>False</usenio>
+        <blocksize>65536</blocksize>
+    </limit>
+    <db>
+        <dbdriver>h2</dbdriver>
+        <dbserver>jdbc:h2:/tmp/ggftp;MODE=PostgreSQL;AUTO_SERVER=TRUE</dbserver>
+        <dbuser>ggftp</dbuser>
+        <dbpasswd>ggftp</dbpasswd>
+    </db>
+</config>

--- a/WaarpR66/src/test/java/org/waarp/openr66/protocol/junit/TestAbstract.java
+++ b/WaarpR66/src/test/java/org/waarp/openr66/protocol/junit/TestAbstract.java
@@ -252,8 +252,6 @@ public abstract class TestAbstract extends TestAbstractMinimal {
     logPrefs.enable(LogType.SERVER, Level.OFF);
     desiredCapabilities
         .setCapability(CapabilityType.LOGGING_PREFS, logPrefs);
-    desiredCapabilities
-        .setCapability(CapabilityType.TAKES_SCREENSHOT, false);
     desiredCapabilities.setCapability(CapabilityType.HAS_NATIVE_EVENTS, true);
     desiredCapabilities.setCapability(PhantomJSDriverService.PHANTOMJS_GHOSTDRIVER_CLI_ARGS, "--webdriver-loglevel=NONE");
     desiredCapabilities.setJavascriptEnabled(true);

--- a/doc/waarp-r66/source/changes.rst
+++ b/doc/waarp-r66/source/changes.rst
@@ -7,7 +7,7 @@ La procédure de mise à jour est disponible ici: :any:`upgrade`
 Non publié
 ==========
 
-Waarp R66 3.3.2 (2020-04-29)
+Waarp R66 3.3.3 (2020-05-05)
 ============================
 
 Correctifs
@@ -21,6 +21,9 @@ Correctifs
 - [`#23 <https://github.com/waarp/Waarp-All/pull/23>`__] Corrige la prise
   en compte d'un chemin sous Windows avec \ qui se double en \\
   (issue [`#22 <https://github.com/waarp/Waarp-All/issues/22>`__])
+- [`#25 <https://github.com/waarp/Waarp-All/pull/25>`__] Corrige l'arrêt
+  immédiat du serveur Waarp GW FTP après son démarrage (introduit en 3.1)
+  (issue [`#24 <https://github.com/waarp/Waarp-All/issues/24>`__])
 - Corrige les dépendances externes
 
 Waarp R66 3.3.2 (2020-04-21)

--- a/pom.xml
+++ b/pom.xml
@@ -237,7 +237,7 @@
     <revision>${waarp.version}</revision>
 
     <!-- Dependencies versions -->
-    <netty.version>4.1.48.Final</netty.version>
+    <netty.version>4.1.49.Final</netty.version>
     <netty-tcnative.version>2.0.30.Final</netty-tcnative.version>
     <waarp-shaded.version>1.0.1</waarp-shaded.version><!-- Netty HTTP and
     Selenuum -->


### PR DESCRIPTION
This issue was introduced in 3.1 after reworking thread pool.
Usually, one activate SNMP in production. In this case, there were no issue.

But if for some reasons, no SNMP was activated, then the GW FTP server
stops immediatey after startup.
    
This fix this issue #24 .