### PR TITLE
Fix issue #26 on DB Connection closed in Admin

### DIFF
--- a/WaarpR66/src/main/java/org/waarp/openr66/context/R66Session.java
+++ b/WaarpR66/src/main/java/org/waarp/openr66/context/R66Session.java
@@ -187,13 +187,11 @@ public class R66Session implements SessionInterface {
   }
 
   /**
-   * Debugging purpose
+   * Debugging purpose (trace)
    *
    * @param stat
    *
-   * @deprecated used only for trace
    */
-  @Deprecated
   public void setStatus(int stat) {
     final StackTraceElement elt = Thread.currentThread().getStackTrace()[2];
     status = '(' + elt.getFileName() + ':' + elt.getLineNumber() + "):" + stat;


### PR DESCRIPTION
In admin interface, espcially in Responsive mode, the DbConnection sometimes
seems closed and not reopened as it should be.

Since the new model of connections is to not keep the connections opens but to
reopen it as much as we need it (seems not to have big impact, and in particular
for Web Admin interface, it should not have any impact), this fix removes the
database keeping rule replacing by the underlying native pooling connections.
    
This fix is made for all Admin Interface: R66, GWFTP, ProxyR66.
    
This is only a fix for #26 , not an evolution.
