### PR TITLE
Fix issue on unlimited connection retry attempts

### DIFF
--- a/WaarpR66/src/main/java/org/waarp/openr66/client/DirectTransfer.java
+++ b/WaarpR66/src/main/java/org/waarp/openr66/client/DirectTransfer.java
@@ -48,6 +48,8 @@ import static org.waarp.common.database.DbConstant.*;
 public class DirectTransfer extends AbstractTransfer {
   protected final NetworkTransaction networkTransaction;
 
+  protected boolean limitRetryConnection = true;
+
   public DirectTransfer(R66Future future, String remoteHost, String filename,
                         String rulename, String fileinfo, boolean isMD5,
                         int blocksize, long id,
@@ -56,6 +58,23 @@ public class DirectTransfer extends AbstractTransfer {
     super(DirectTransfer.class, future, filename, rulename, fileinfo, isMD5,
           remoteHost, blocksize, id, null);
     this.networkTransaction = networkTransaction;
+  }
+
+  /**
+   *
+   * @return True if this DirectTransfer should limit the retry of connection
+   */
+  public boolean isLimitRetryConnection() {
+    return limitRetryConnection;
+  }
+
+  /**
+   *
+   * @param limitRetryConnection True (default) for limited retry on
+   * connection, False to have no limit
+   */
+  public void setLimitRetryConnection(final boolean limitRetryConnection) {
+    this.limitRetryConnection = limitRetryConnection;
   }
 
   /**
@@ -75,6 +94,8 @@ public class DirectTransfer extends AbstractTransfer {
     }
     final ClientRunner runner =
         new ClientRunner(networkTransaction, taskRunner, future);
+    // If retry indefinitely is useful
+    runner.setLimitRetryConnection(isLimitRetryConnection());
     OpenR66ProtocolNotYetConnectionException exc = null;
     for (int i = 0; i < Configuration.RETRYNB; i++) {
       try {

--- a/WaarpR66/src/main/java/org/waarp/openr66/database/data/DbTaskRunner.java
+++ b/WaarpR66/src/main/java/org/waarp/openr66/database/data/DbTaskRunner.java
@@ -791,6 +791,8 @@ public class DbTaskRunner extends AbstractDbDataDao<Transfer> {
       if (Configuration.configuration.getR66Mib() != null) {
         Configuration.configuration.getR66Mib().notifyInfoTask(
             "Task is " + pojo.getUpdatedInfo().name(), this);
+      } else {
+        logger.debug("Could send a SNMP trap here since {}", pojo.getUpdatedInfo());
       }
     } else {
       if (pojo.getGlobalStep() != Transfer.TASKSTEP.TRANSFERTASK ||

--- a/WaarpR66/src/test/resources/Linux/config/rulerecv-any.rule.xml
+++ b/WaarpR66/src/test/resources/Linux/config/rulerecv-any.rule.xml
@@ -47,7 +47,7 @@
 		<tasks>
 			<task>
 				<type>LOG</type>
-				<path>erreur</path>
+				<path>error erreur</path>
 				<delay>1</delay>
 				<rank>0</rank>
 			</task>
@@ -77,7 +77,7 @@
 		<tasks>
 			<task>
 				<type>LOG</type>
-				<path>erreur</path>
+				<path>error erreur</path>
 				<delay>1</delay>
 				<rank>0</rank>
 			</task>

--- a/WaarpR66/src/test/resources/Linux/config/rulerecv.rule.xml
+++ b/WaarpR66/src/test/resources/Linux/config/rulerecv.rule.xml
@@ -51,7 +51,7 @@
 		<tasks>
 			<task>
 				<type>LOG</type>
-				<path>erreur</path>
+				<path>error erreur</path>
 				<delay>1</delay>
 				<rank>0</rank>
 			</task>
@@ -61,7 +61,7 @@
 		<tasks>
 			<task>
 				<type>LOG</type>
-				<path>erreur</path>
+				<path>error erreur</path>
 				<delay>1</delay>
 				<rank>0</rank>
 			</task>

--- a/WaarpR66/src/test/resources/Linux/config/rulerecvthrough-any.rule.xml
+++ b/WaarpR66/src/test/resources/Linux/config/rulerecvthrough-any.rule.xml
@@ -47,7 +47,7 @@
 		<tasks>
 			<task>
 				<type>LOG</type>
-				<path>erreur</path>
+				<path>error erreur</path>
 				<delay>1</delay>
 				<rank>0</rank>
 			</task>
@@ -57,7 +57,7 @@
 		<tasks>
 			<task>
 				<type>LOG</type>
-				<path>erreur</path>
+				<path>error erreur</path>
 				<delay>1</delay>
 				<rank>0</rank>
 			</task>

--- a/WaarpR66/src/test/resources/Linux/config/rulesend-any-delete.rule.xml
+++ b/WaarpR66/src/test/resources/Linux/config/rulesend-any-delete.rule.xml
@@ -61,7 +61,7 @@
 		<tasks>
 			<task>
 				<type>LOG</type>
-				<path>erreur</path>
+				<path>error erreur</path>
 				<delay>1</delay>
 				<rank>0</rank>
 			</task>
@@ -71,7 +71,7 @@
 		<tasks>
 			<task>
 				<type>LOG</type>
-				<path>erreur</path>
+				<path>error erreur</path>
 				<delay>1</delay>
 				<rank>0</rank>
 			</task>

--- a/WaarpR66/src/test/resources/Linux/config/rulesend-any.rule.xml
+++ b/WaarpR66/src/test/resources/Linux/config/rulesend-any.rule.xml
@@ -47,7 +47,7 @@
 		<tasks>
 			<task>
 				<type>LOG</type>
-				<path>erreur</path>
+				<path>error erreur</path>
 				<delay>1</delay>
 				<rank>0</rank>
 			</task>
@@ -57,7 +57,7 @@
 		<tasks>
 			<task>
 				<type>LOG</type>
-				<path>erreur</path>
+				<path>error erreur</path>
 				<delay>1</delay>
 				<rank>0</rank>
 			</task>

--- a/WaarpR66/src/test/resources/Linux/config/rulesend.rule.xml
+++ b/WaarpR66/src/test/resources/Linux/config/rulesend.rule.xml
@@ -56,7 +56,7 @@
 		<tasks>
 			<task>
 				<type>LOG</type>
-				<path>erreur</path>
+				<path>error erreur</path>
 				<delay>1</delay>
 				<rank>0</rank>
 			</task>
@@ -66,7 +66,7 @@
 		<tasks>
 			<task>
 				<type>LOG</type>
-				<path>erreur</path>
+				<path>error erreur</path>
 				<delay>1</delay>
 				<rank>0</rank>
 			</task>

--- a/WaarpR66/src/test/resources/Linux/config/rulesendthrough-any.rule.xml
+++ b/WaarpR66/src/test/resources/Linux/config/rulesendthrough-any.rule.xml
@@ -47,7 +47,7 @@
 		<tasks>
 			<task>
 				<type>LOG</type>
-				<path>erreur</path>
+				<path>error erreur</path>
 				<delay>1</delay>
 				<rank>0</rank>
 			</task>
@@ -57,7 +57,7 @@
 		<tasks>
 			<task>
 				<type>LOG</type>
-				<path>erreur</path>
+				<path>error erreur</path>
 				<delay>1</delay>
 				<rank>0</rank>
 			</task>

--- a/doc/waarp-r66/source/changes.rst
+++ b/doc/waarp-r66/source/changes.rst
@@ -28,6 +28,10 @@ Correctifs
   de connections à la base de données pour l'interface d'administration
   en mode Responsive
   (issue [`#26 <https://github.com/waarp/Waarp-All/issues/26>`__])
+- [`#30 <https://github.com/waarp/Waarp-All/pull/30>`__]
+  Corrige la régression sur la répétition à l'infini des tentatives
+  de connexion depuis la version 3.1. Le principe de 3 tentatives avant échec
+  est rétabli.
 - Corrige les dépendances externes (et le style)
 
 Waarp R66 3.3.2 (2020-04-21)

--- a/pom.xml
+++ b/pom.xml
@@ -237,7 +237,7 @@
     <revision>${waarp.version}</revision>
 
     <!-- Dependencies versions -->
-    <netty.version>4.1.49.Final</netty.version>
+    <netty.version>4.1.50.Final</netty.version>
     <netty-tcnative.version>2.0.30.Final</netty-tcnative.version>
     <waarp-shaded.version>1.0.1</waarp-shaded.version><!-- Netty HTTP and
     Selenuum -->


### PR DESCRIPTION
During fix on version 3.1/3.3, several issues concerning forwarding transfers
and FileMonitor introduce a endless repetition of attemps in case of lack
of connection.
This fixes this issue:

- After 3 attemps of failed connections, the transfer is in error and the
execution of the error task is launched
- For FileMonitor (SpooledDirectoryTransfer), a failed Submit transfer is handled
by the R66 server as usual (3 attempts). For Direct transfer, the retry after 3
attemps is done after a delay, as long as the file exists.