### PR TITLE
Fix issue on wrong argument on requester host

### DIFF
--- a/WaarpCommon/src/main/java/org/waarp/common/xml/XmlUtil.java
+++ b/WaarpCommon/src/main/java/org/waarp/common/xml/XmlUtil.java
@@ -588,8 +588,8 @@ public final class XmlUtil {
             continue;
           }
           for (final Node element : elts) {
-            final XmlValue[] newValue = read((Element) element,
-                                             decls[i].getSubXml());
+            final XmlValue[] newValue =
+                read((Element) element, decls[i].getSubXml());
             if (newValue == null) {
               continue;
             }
@@ -675,8 +675,8 @@ public final class XmlUtil {
             continue;
           }
           for (final Node element : elts) {
-            final XmlValue[] newValue = read((Element) element,
-                                             decls[i].getSubXml());
+            final XmlValue[] newValue =
+                read((Element) element, decls[i].getSubXml());
             if (newValue == null) {
               continue;
             }

--- a/WaarpR66/src/main/java/org/waarp/openr66/client/DirectTransfer.java
+++ b/WaarpR66/src/main/java/org/waarp/openr66/client/DirectTransfer.java
@@ -61,7 +61,6 @@ public class DirectTransfer extends AbstractTransfer {
   }
 
   /**
-   *
    * @return True if this DirectTransfer should limit the retry of connection
    */
   public boolean isLimitRetryConnection() {
@@ -69,9 +68,8 @@ public class DirectTransfer extends AbstractTransfer {
   }
 
   /**
-   *
    * @param limitRetryConnection True (default) for limited retry on
-   * connection, False to have no limit
+   *     connection, False to have no limit
    */
   public void setLimitRetryConnection(final boolean limitRetryConnection) {
     this.limitRetryConnection = limitRetryConnection;

--- a/WaarpR66/src/main/java/org/waarp/openr66/client/RequestTransfer.java
+++ b/WaarpR66/src/main/java/org/waarp/openr66/client/RequestTransfer.java
@@ -134,8 +134,7 @@ public class RequestTransfer implements Runnable {
         }
         rhost = srequested;
         try {
-          srequester = Configuration.configuration
-              .getHostId(admin.getSession(), srequested);
+          srequester = Configuration.configuration.getHostId(srequested);
         } catch (final WaarpDatabaseException e) {
           logger.error(Messages.getString("RequestTransfer.5") + srequested,
                        e); //$NON-NLS-1$
@@ -149,8 +148,7 @@ public class RequestTransfer implements Runnable {
         }
         rhost = srequester;
         try {
-          srequested = Configuration.configuration
-              .getHostId(admin.getSession(), srequester);
+          srequested = Configuration.configuration.getHostId(srequester);
         } catch (final WaarpDatabaseException e) {
           logger.error(Messages.getString("RequestTransfer.5") + srequester,
                        e); //$NON-NLS-1$

--- a/WaarpR66/src/main/java/org/waarp/openr66/client/SpooledDirectoryTransfer.java
+++ b/WaarpR66/src/main/java/org/waarp/openr66/client/SpooledDirectoryTransfer.java
@@ -488,8 +488,8 @@ public class SpooledDirectoryTransfer implements Runnable {
                 ' ' + filename + ' ';
             try {
               R66Future r66Future = new R66Future(true);
-              final String srequester = Configuration.configuration
-                  .getHostId(admin.getSession(), host);
+              final String srequester =
+                  Configuration.configuration.getHostId(host);
               // Try restart
               final RequestTransfer transaction =
                   new RequestTransfer(r66Future, fileItem.specialId, host,
@@ -502,6 +502,7 @@ public class SpooledDirectoryTransfer implements Runnable {
               r66Future.awaitOrInterruptible();
               // reset fileItem usage
               setValid(fileItem);
+              specialId = fileItem.specialId;
             } catch (final WaarpDatabaseException e) {
               if (admin.getSession() != null) {
                 admin.getSession().checkConnectionNoException();
@@ -534,11 +535,10 @@ public class SpooledDirectoryTransfer implements Runnable {
               if (specialId != ILLEGALVALUE) {
                 // Clean previously transfer if any
                 try {
-                  final String srequester = Configuration.configuration
-                      .getHostId(admin.getSession(), host);
-                  text =
-                      "Request Transfer Cancelled: " + specialId +
-                      ' ' + filename + ' ';
+                  final String srequester =
+                      Configuration.configuration.getHostId(host);
+                  text = "Request Transfer Cancelled: " + specialId + ' ' +
+                         filename + ' ';
                   // Cancel
                   logger.debug("Will try to cancel {}", specialId);
                   final RequestTransfer transaction2 =

--- a/WaarpR66/src/main/java/org/waarp/openr66/database/data/DbTaskRunner.java
+++ b/WaarpR66/src/main/java/org/waarp/openr66/database/data/DbTaskRunner.java
@@ -383,8 +383,7 @@ public class DbTaskRunner extends AbstractDbDataDao<Transfer> {
     originalSize = requestPacket.getOriginalSize();
     setOriginalSizeTransferMap(originalSize);
     // itself but according to SSL
-    pojo.setRequester(
-        Configuration.configuration.getHostId(dbSession, requested));
+    pojo.setRequester(Configuration.configuration.getHostId(requested));
 
     // Retrieve rule
     this.rule = new DbRule(getRuleId());
@@ -684,9 +683,9 @@ public class DbTaskRunner extends AbstractDbDataDao<Transfer> {
     logger.trace("TRACE ID {}", id);
     try {
       transferAccess = DAOFactory.getInstance().getTransferDAO();
-      pojo = transferAccess
-          .select(id, Configuration.configuration.getHostId(), requested,
-                  Configuration.configuration.getHostId());
+      String requester = Configuration.configuration.getHostId(requested);
+      pojo = transferAccess.select(id, requester, requested,
+                                   Configuration.configuration.getHostId());
     } catch (final DAOConnectionException e) {
       throw new WaarpDatabaseException(e);
     } catch (final DAONoDataException e) {
@@ -792,7 +791,8 @@ public class DbTaskRunner extends AbstractDbDataDao<Transfer> {
         Configuration.configuration.getR66Mib().notifyInfoTask(
             "Task is " + pojo.getUpdatedInfo().name(), this);
       } else {
-        logger.debug("Could send a SNMP trap here since {}", pojo.getUpdatedInfo());
+        logger.debug("Could send a SNMP trap here since {}",
+                     pojo.getUpdatedInfo());
       }
     } else {
       if (pojo.getGlobalStep() != Transfer.TASKSTEP.TRANSFERTASK ||

--- a/WaarpR66/src/main/java/org/waarp/openr66/protocol/configuration/Configuration.java
+++ b/WaarpR66/src/main/java/org/waarp/openr66/protocol/configuration/Configuration.java
@@ -1408,21 +1408,34 @@ public class Configuration {
   }
 
   /**
-   * @param dbSession
    * @param remoteHost
    *
    * @return the HostId according to remoteHost (and its SSL status)
    *
    * @throws WaarpDatabaseException
    */
-  public String getHostId(DbSession dbSession, String remoteHost)
-      throws WaarpDatabaseException {
+  public String getHostId(String remoteHost) throws WaarpDatabaseException {
     final DbHostAuth dbHostAuth = new DbHostAuth(remoteHost);
     try {
       return configuration.getHostId(dbHostAuth.isSsl());
     } catch (final OpenR66ProtocolNoSslException e) {
       throw new WaarpDatabaseException(e);
     }
+  }
+
+  /**
+   * @param dbSession
+   * @param remoteHost
+   *
+   * @return the HostId according to remoteHost (and its SSL status)
+   *
+   * @throws WaarpDatabaseException
+   * @deprecated Use getHostId(String remoteHost)
+   */
+  @Deprecated
+  public String getHostId(DbSession dbSession, String remoteHost)
+      throws WaarpDatabaseException {
+    return getHostId(remoteHost);
   }
 
   private static class UsageStatistic extends TimerTask {

--- a/WaarpR66/src/main/java/org/waarp/openr66/protocol/localhandler/LocalChannelReference.java
+++ b/WaarpR66/src/main/java/org/waarp/openr66/protocol/localhandler/LocalChannelReference.java
@@ -156,10 +156,6 @@ public class LocalChannelReference {
    * PartnerConfiguration
    */
   private volatile PartnerConfiguration partner;
-  /**
-   * DbSession for Database that do not support concurrency in access
-   */
-  private volatile DbSession noconcurrencyDbSession;
 
   /**
    * @param networkChannelRef
@@ -280,9 +276,6 @@ public class LocalChannelReference {
    * @return the actual dbSession
    */
   public DbSession getDbSession() {
-    if (noconcurrencyDbSession != null) {
-      return noconcurrencyDbSession;
-    }
     if (networkServerHandler != null) {
       return networkServerHandler.getDbSession();
     }

--- a/WaarpR66/src/main/java/org/waarp/openr66/protocol/localhandler/ServerActions.java
+++ b/WaarpR66/src/main/java/org/waarp/openr66/protocol/localhandler/ServerActions.java
@@ -2618,16 +2618,13 @@ public class ServerActions extends ConnectionActions {
       throw new OpenR66ProtocolNotAuthenticatedException(
           "Not authenticated while Information received");
     }
-    final DbSession dbSession =
-        localChannelReference != null? localChannelReference.getDbSession() :
-            admin.getSession();
     String remote = session.getAuth().getUser();
     if (jsonOutput && remoteHost != null && !remoteHost.isEmpty()) {
       remote = remoteHost;
     }
     String local;
     try {
-      local = Configuration.configuration.getHostId(dbSession, remote);
+      local = Configuration.configuration.getHostId(remote);
     } catch (final WaarpDatabaseException e1) {
       logger.error("Remote Host is unknown", e1);
       throw new OpenR66ProtocolNoDataException("Remote Host is unknown", e1);

--- a/doc/waarp-r66/source/changes.rst
+++ b/doc/waarp-r66/source/changes.rst
@@ -7,6 +7,17 @@ La procédure de mise à jour est disponible ici: :any:`upgrade`
 Non publié
 ==========
 
+Waarp R66 3.3.3 (2020-06-01)
+============================
+
+Correctifs
+==========
+
+- [`#31 <https://github.com/waarp/Waarp-All/pull/31>`__]
+  Corrige la régression sur la sélection d'un transfert à partir de son ID
+  où le nom du serveur local ne prenait pas en compte si le serveur
+  distant était en mode SSL ou pas (régression en 3.0).
+
 Waarp R66 3.3.3 (2020-05-07)
 ============================
 

--- a/pom.xml
+++ b/pom.xml
@@ -308,7 +308,7 @@
     <maven.resources.version>3.1.0</maven.resources.version>
     <maven.source.version>3.2.1</maven.source.version>
     <maven.dependency.version>3.1.2</maven.dependency.version>
-    <maven.site.version>3.9.0</maven.site.version>
+    <maven.site.version>3.8.2</maven.site.version>
     <maven.assembly.version>3.3.0</maven.assembly.version>
     <maven.javadoc.version>3.2.0</maven.javadoc.version>
     <maven.exec.version>1.6.0</maven.exec.version>
@@ -1383,6 +1383,7 @@
         <configuration>
           <skipEmptyReport>true</skipEmptyReport>
           <dependencyDetailsEnabled>true</dependencyDetailsEnabled>
+          <dependencyLocationsEnabled>false</dependencyLocationsEnabled>
           <!-- <skip>${module.project}</skip> -->
         </configuration>
         <reportSets>


### PR DESCRIPTION
During change to DAO, one particular DbTaskRunner constructor
was wrongly modified, not taking into account the remote host
type (ssl or not) to get the local name of the host (again, ssl
or not).

This fix this issue, restablishing the original behavior.
Note that an existing method is marked as deprecated but kept
in order to allow upward compatiblity.