### PR TITLE
Fix documentation example

### DIFF
--- a/doc/waarp-r66/source/changes.rst
+++ b/doc/waarp-r66/source/changes.rst
@@ -28,6 +28,8 @@ Correctifs
   (issue [`#37 <https://github.com/waarp/Waarp-All/issues/37>`__])
 - Nettoyage du code
 - Corrige l'intégration de SonarQube avec Maven
+- Corrige l'exemple de la documentation sur l'authentification HMAC (pull
+  request [`#38 <https://github.com/waarp/Waarp-All/pull/38>`__])
 
 Waarp R66 3.3.3 (2020-05-07)
 ============================

--- a/doc/waarp-r66/source/interface/restv2/authentication.rst
+++ b/doc/waarp-r66/source/interface/restv2/authentication.rst
@@ -4,8 +4,6 @@ Authentification des requêtes
 Lorsque l'authentification des requêtes est activée dans la configuration REST du serveur,
 celle-ci peut se faire de 2 manières différentes.
 
---------------------------------------------------------------------------------------------------------------
-
 Authentification Basique
 ========================
 
@@ -30,8 +28,6 @@ Cette authentification se fait avec les entêtes suivants :
       -> ``Basic dG90bzp0b3RvbWRw`` après encodage
       
       
---------------------------------------------------------------------------------------------------------------
-    
 Authentification HMAC
 =====================
 
@@ -62,6 +58,6 @@ Cette authentification se fait avec les entêtes suivants :
   * *exemple* : Pour l'utilisateur 'toto' avec le mot de passe 'totomdp' à la date '1970-01-01T01:00:00+00:00'
     cela donne
     
-    -> ``HMAC totototomdp1970-01-01T01:00:00+00:00`` avant hachage
+    -> ``HMAC 1970-01-01T01:00:00+00:00totototomdp`` avant hachage
     
     -> ``HMAC e4219167eb4cf1f8590d684713218c4ad011d475d8f3b2d37fb15ce3da675021`` après hachage


### PR DESCRIPTION
The description is OK confirm to the code, but not the example (elements are in the wrong order)