### PR TITLE
Fix the Header used for signature in Rest v2

### DIFF
--- a/WaarpR66/src/main/java/org/waarp/openr66/protocol/http/restv2/RestConstants.java
+++ b/WaarpR66/src/main/java/org/waarp/openr66/protocol/http/restv2/RestConstants.java
@@ -116,7 +116,7 @@ public final class RestConstants {
    * Name of the HTTP header used to store the signature key of a request.
    */
   public static final AsciiString AUTH_SIGNATURE =
-      AsciiString.cached("X-Auth-Key");
+      AsciiString.cached("X-Auth-Signature");
 
   // ########################## ENTRY POINTS URI ##############################
 

--- a/doc/waarp-r66/source/changes.rst
+++ b/doc/waarp-r66/source/changes.rst
@@ -30,6 +30,8 @@ Correctifs
 - Corrige l'intégration de SonarQube avec Maven
 - Corrige l'exemple de la documentation sur l'authentification HMAC (pull
   request [`#38 <https://github.com/waarp/Waarp-All/pull/38>`__])
+- Correction de la signature des requêtes dans l'API REST v2 (pull
+  request [`#42 <https://github.com/waarp/Waarp-All/pull/42>`__])
 
 Waarp R66 3.3.3 (2020-05-07)
 ============================


### PR DESCRIPTION
The RAML specification and the documentation both refer to the
`X-Auth-Signature`, but the header `X-Auth-Key` is actually used.

This PR changes the header used to be conform to the specification.