### PR TITLE
Fixes the HMAC Authentication of RESTv2

### DIFF
--- a/WaarpCommon/src/main/java/org/waarp/common/crypto/KeyObject.java
+++ b/WaarpCommon/src/main/java/org/waarp/common/crypto/KeyObject.java
@@ -389,6 +389,20 @@ public abstract class KeyObject {
   }
 
   /**
+   * Decrypt a String as HEX format representing a crypted String and
+   * returns the uncrypted String
+   *
+   * @param ciphertext
+   *
+   * @return the uncrypted String
+   *
+   * @throws Exception
+   */
+  public String decryptHexInString(byte[] ciphertext) throws Exception {
+    return new String(decryptHexInBytes(ciphertext), WaarpStringUtils.UTF8);
+  }
+
+  /**
    * Decode from a file containing a HEX crypted string
    *
    * @param file

--- a/WaarpCommon/src/test/java/org/waarp/common/crypto/DynamicKeyObjectTest.java
+++ b/WaarpCommon/src/test/java/org/waarp/common/crypto/DynamicKeyObjectTest.java
@@ -55,6 +55,22 @@ public class DynamicKeyObjectTest {
     }
   }
 
+  @Test
+  public void testDecryptHexInString() throws Exception {
+    final INSTANCES keyAlgo = INSTANCES.DES;
+    final DynamicKeyObject dyn = new DynamicKeyObject(
+      keyAlgo.size, keyAlgo.name(), keyAlgo.name(), keyAlgo.name()
+    );
+
+    dyn.generateKey();
+    final String original = "mypassword";
+    final byte[] crypted = dyn.crypt(original);
+    final String cryptedHex = dyn.encodeHex(crypted);
+    final String decrypted = dyn.decryptHexInString(cryptedHex);
+
+    assertEquals("decrypted password should be equal to the original", original, decrypted);
+  }
+
   /**
    * test function
    *

--- a/WaarpR66/src/test/java/org/waarp/openr66/protocol/http/restv2/resthandlers/RestHandlerHookTest.java
+++ b/WaarpR66/src/test/java/org/waarp/openr66/protocol/http/restv2/resthandlers/RestHandlerHookTest.java
@@ -1,0 +1,70 @@
+package org.waarp.openr66.protocol.http.restv2.resthandlers;
+
+import org.junit.Test;
+import org.waarp.common.crypto.Des;
+import org.waarp.common.crypto.DynamicKeyObject;
+import org.waarp.common.crypto.HmacSha256;
+import org.waarp.openr66.pojo.Host;
+import org.waarp.openr66.protocol.configuration.Configuration;
+
+import static org.junit.Assert.fail;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import javax.ws.rs.InternalServerErrorException;
+
+/**
+ * RestHandlerHook
+ */
+public class RestHandlerHookTest {
+
+  public static final class RestHandlerHookForTest extends RestHandlerHook {
+    public RestHandlerHookForTest(final boolean authenticated,
+                                  final HmacSha256 hmac, final long delay) {
+      super(authenticated, hmac, delay);
+    }
+
+    public void testValidateHMACredentials(Host host, String authDate,
+                                       String authUser, String authKey)
+        throws InternalServerErrorException {
+      validateHMACCredentials(host, authDate, authUser, authKey);
+    }
+  }
+
+  @Test
+  public void testCheckCredentialsWithHMAC() throws Exception{
+    final HmacSha256 hmac = new HmacSha256();
+    hmac.generateKey();
+
+    final Des dyn = new Des();
+    dyn.generateKey();
+    Des oldKey = Configuration.configuration.getCryptoKey();
+    Configuration.configuration.setCryptoKey(dyn);
+
+    final String user = "user";
+    final String password = "mypassword";
+    final String timestamp = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXX").format(new Date());
+
+    try {
+
+      final String hostkey = dyn.cryptToHex(password);
+      final String sig = hmac.cryptToHex(timestamp + user + password);
+
+      final RestHandlerHookForTest hook = new RestHandlerHookForTest(true, hmac, 10000);
+
+      try {
+        final Host host = new Host(user, "127.0.0.1", 1, hostkey.getBytes(), false, true);
+
+        hook.testValidateHMACredentials(host, timestamp, user, sig);
+      } catch (InternalServerErrorException e) {
+        System.out.println(e);
+        fail("credentials validation failed, it should have succeeded");
+      }
+
+    } finally {
+      Configuration.configuration.setCryptoKey(oldKey);
+    }
+
+  }
+}

--- a/doc/waarp-r66/source/changes.rst
+++ b/doc/waarp-r66/source/changes.rst
@@ -32,6 +32,8 @@ Correctifs
   request [`#38 <https://github.com/waarp/Waarp-All/pull/38>`__])
 - Correction de la signature des requêtes dans l'API REST v2 (pull
   request [`#42 <https://github.com/waarp/Waarp-All/pull/42>`__])
+- Correction de l'authentification HMAC de l'API REST v2 (pull
+  request [`#43 <https://github.com/waarp/Waarp-All/pull/43>`__])
 
 Waarp R66 3.3.3 (2020-05-07)
 ============================


### PR DESCRIPTION
Two problems prevented the authentication:
- the password deciphering expected a string and not an hex string (as returned
  by the database), which caused padding exceptions
- the HMAC sum comparison was done in bytes instead of strings, which somehow
  returned false