### PR TITLE
Fix for Block Size

### DIFF
--- a/WaarpCommon/src/main/java/org/waarp/common/utility/WaarpNettyUtil.java
+++ b/WaarpCommon/src/main/java/org/waarp/common/utility/WaarpNettyUtil.java
@@ -24,6 +24,7 @@ import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.WriteBufferWaterMark;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.util.concurrent.Future;
@@ -35,7 +36,11 @@ import org.waarp.common.logging.SysErrLogger;
 public final class WaarpNettyUtil {
 
   private static final int TIMEOUT_MILLIS = 1000;
+  // Default optimal value for Waarp
   private static final int BUFFER_SIZE_1MB = 1048576;
+  // Default optimal value from Netty (tested as correct for Waarp)
+  private static final int DEFAULT_LOW_WATER_MARK = 32 * 1024;
+  private static final int DEFAULT_HIGH_WATER_MARK = 64 * 1024;
 
   private WaarpNettyUtil() {
   }
@@ -57,6 +62,9 @@ public final class WaarpNettyUtil {
     bootstrap.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, timeout);
     bootstrap.option(ChannelOption.SO_RCVBUF, BUFFER_SIZE_1MB);
     bootstrap.option(ChannelOption.SO_SNDBUF, BUFFER_SIZE_1MB);
+    bootstrap.option(ChannelOption.WRITE_BUFFER_WATER_MARK,
+                     new WriteBufferWaterMark(DEFAULT_LOW_WATER_MARK,
+                                              DEFAULT_HIGH_WATER_MARK));
     bootstrap.option(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT);
   }
 
@@ -79,6 +87,9 @@ public final class WaarpNettyUtil {
     bootstrap.childOption(ChannelOption.CONNECT_TIMEOUT_MILLIS, timeout);
     bootstrap.childOption(ChannelOption.SO_RCVBUF, BUFFER_SIZE_1MB);
     bootstrap.childOption(ChannelOption.SO_SNDBUF, BUFFER_SIZE_1MB);
+    bootstrap.childOption(ChannelOption.WRITE_BUFFER_WATER_MARK,
+                          new WriteBufferWaterMark(DEFAULT_LOW_WATER_MARK,
+                                                   DEFAULT_HIGH_WATER_MARK));
     bootstrap
         .childOption(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT);
   }

--- a/WaarpR66/src/main/java/org/waarp/openr66/database/data/DbTaskRunner.java
+++ b/WaarpR66/src/main/java/org/waarp/openr66/database/data/DbTaskRunner.java
@@ -2151,6 +2151,13 @@ public class DbTaskRunner extends AbstractDbDataDao<Transfer> {
   }
 
   /**
+   * @param blocksize the block size to set
+   */
+  public void setBlocksize(int blocksize) {
+    pojo.setBlockSize(blocksize);
+  }
+
+  /**
    * @param filename the filename to set
    */
   public void setFilename(String filename) {

--- a/WaarpR66/src/main/java/org/waarp/openr66/protocol/http/restv2/converters/TransferConverter.java
+++ b/WaarpR66/src/main/java/org/waarp/openr66/protocol/http/restv2/converters/TransferConverter.java
@@ -173,7 +173,7 @@ public final class TransferConverter {
         new Transfer(null, null, -1, false, null, null, 65536);
     defaultTransfer.setRequester(serverName());
     defaultTransfer.setOwnerRequest(serverName());
-    defaultTransfer.setBlockSize(65536);
+    defaultTransfer.setBlockSize(Configuration.configuration.getBlockSize());
     defaultTransfer.setTransferInfo("");
     defaultTransfer.setStart(new Timestamp(DateTime.now().getMillis()));
     final Transfer transfer = parseNode(object, defaultTransfer);

--- a/WaarpR66/src/main/java/org/waarp/openr66/protocol/localhandler/TransferActions.java
+++ b/WaarpR66/src/main/java/org/waarp/openr66/protocol/localhandler/TransferActions.java
@@ -212,6 +212,12 @@ public class TransferActions extends ServerActions {
     }
     // Receiver can specify a rank different from database
     setRankAtStartupFromRequest(packet, runner);
+    runner.setBlocksize(packet.getBlocksize());
+    try {
+      runner.update();
+    } catch (WaarpDatabaseException ignored) {
+      // Ignore
+    }
     logger.debug(
         "Filesize: " + packet.getOriginalSize() + ':' + runner.isSender());
     boolean shouldInformBack = false;
@@ -287,6 +293,8 @@ public class TransferActions extends ServerActions {
       }
       // Check if the blocksize is greater than local value
       if (Configuration.configuration.getBlockSize() < blocksize) {
+        logger.warn("Blocksize is greater than allowed {} < {}",
+                    Configuration.configuration.getBlockSize(), blocksize);
         blocksize = Configuration.configuration.getBlockSize();
         final String sep = localChannelReference.getPartner().getSeperator();
         packet = new RequestPacket(packet.getRulename(), packet.getMode(),

--- a/WaarpR66/src/test/resources/it/scenario_1_2_3/R1/conf/server_1.xml
+++ b/WaarpR66/src/test/resources/it/scenario_1_2_3/R1/conf/server_1.xml
@@ -85,6 +85,7 @@
         <globaldigest>True</globaldigest>
         <delaycommand>5000</delaycommand>
         <runlimit>600</runlimit>
+        <blocksize>1048576</blocksize>
     </limit>
     <db>
         <dbdriver>h2</dbdriver>

--- a/WaarpR66/src/test/resources/it/scenario_1_2_3/R1/conf/server_1_SQLDB.xml
+++ b/WaarpR66/src/test/resources/it/scenario_1_2_3/R1/conf/server_1_SQLDB.xml
@@ -84,7 +84,8 @@
     <digest>5</digest>
     <globaldigest>True</globaldigest>
     <delaycommand>5000</delaycommand>
-    <runlimit>600</runlimit>
+    <runlimit>800</runlimit>
+    <blocksize>1048576</blocksize>
   </limit>
   <db>
     <dbdriver>XXXDRIVERXXX</dbdriver>

--- a/WaarpR66/src/test/resources/it/scenario_1_2_3/R2/conf/server_2.xml
+++ b/WaarpR66/src/test/resources/it/scenario_1_2_3/R2/conf/server_2.xml
@@ -84,6 +84,7 @@
         <digest>5</digest>
         <globaldigest>True</globaldigest>
         <runlimit>1000</runlimit>
+        <blocksize>1048576</blocksize>
     </limit>
     <db>
         <dbdriver>h2</dbdriver>

--- a/doc/waarp-r66/source/changes.rst
+++ b/doc/waarp-r66/source/changes.rst
@@ -34,6 +34,8 @@ Correctifs
   request [`#42 <https://github.com/waarp/Waarp-All/pull/42>`__])
 - Correction de l'authentification HMAC de l'API REST v2 (pull
   request [`#43 <https://github.com/waarp/Waarp-All/pull/43>`__])
+- Correction d'un bug sur la taille des paquets (pull
+  request [`#45 <https://github.com/waarp/Waarp-All/pull/45>`__])
 
 Waarp R66 3.3.3 (2020-05-07)
 ============================


### PR DESCRIPTION
In some cases, the given block size could be wrong on receiver side, in particular
when it receives from its own initiative (Pull) a file and when one of the server
has an upper limit below this requested size.

This fix this issue.