### PR TITLE
Add option follow for transfer and Rest V2

### DIFF
--- a/WaarpCommon/src/test/java/org/waarp/common/guid/LongUuidTest.java
+++ b/WaarpCommon/src/test/java/org/waarp/common/guid/LongUuidTest.java
@@ -95,7 +95,7 @@ public class LongUuidTest {
   public void testPIDField() throws Exception {
     final LongUuid id = new LongUuid();
 
-    assertEquals(JvmProcessId.jvmProcessId() & 0x7FFF, id.getProcessId());
+    assertEquals(JvmProcessId.jvmProcessId() & 0xFFFF, id.getProcessId());
   }
 
   @Test

--- a/WaarpCommon/src/test/java/org/waarp/common/guid/LongUuidTest.java
+++ b/WaarpCommon/src/test/java/org/waarp/common/guid/LongUuidTest.java
@@ -95,7 +95,7 @@ public class LongUuidTest {
   public void testPIDField() throws Exception {
     final LongUuid id = new LongUuid();
 
-    assertEquals(JvmProcessId.jvmProcessId(), id.getProcessId());
+    assertEquals(JvmProcessId.jvmProcessId() & 0x7FFF, id.getProcessId());
   }
 
   @Test

--- a/WaarpGatewayFtp/src/main/java/org/waarp/gateway/ftp/exec/R66PreparedTransferExecutor.java
+++ b/WaarpGatewayFtp/src/main/java/org/waarp/gateway/ftp/exec/R66PreparedTransferExecutor.java
@@ -100,7 +100,7 @@ public class R66PreparedTransferExecutor extends AbstractExecutor {
    * (-file <arg>     Specify the file path to operate on<br>
    * -rule <arg>))    Specify the Rule<br>
    * [-block <arg>]   Specify the block size<br>
-   * [-follow]        Specify the transfer should integrate a FOLLOW id<br>
+   * [-nofollow]      Specify the transfer should not integrate a FOLLOW id<br>
    * [-md5]           Specify the option to have a hash computed for the
    * transfer<br>
    * [-delay <arg>]   Specify the delay time as an epoch time or '+' a delay in ms<br>
@@ -154,7 +154,7 @@ public class R66PreparedTransferExecutor extends AbstractExecutor {
         "R66Prepared with -to " + transferArgs.getRemoteHost() + " -rule " +
         transferArgs.getRulename() + " -file " + transferArgs.getFilename() +
         " -nolog: " + nolog + " -isMD5: " + transferArgs.isMD5() + " -info " +
-        transferArgs.getFileinfo();
+        transferArgs.getTransferInfo();
     logger.debug(message);
     DbRule rule;
     try {
@@ -184,7 +184,7 @@ public class R66PreparedTransferExecutor extends AbstractExecutor {
         new RequestPacket(transferArgs.getRulename(), mode,
                           transferArgs.getFilename(),
                           transferArgs.getBlockSize(), 0, ILLEGALVALUE,
-                          transferArgs.getFileinfo(), originalSize, sep);
+                          transferArgs.getTransferInfo(), originalSize, sep);
     // Not isRecv since it is the requester, so send => isRetrieve is true
     final boolean isRetrieve = !RequestPacket.isRecvMode(request.getMode());
     logger.debug("Will prepare: {}", request);

--- a/WaarpIcap/src/test/java/org/waarp/icap/IcapScanFileTest.java
+++ b/WaarpIcap/src/test/java/org/waarp/icap/IcapScanFileTest.java
@@ -881,8 +881,8 @@ public class IcapScanFileTest {
     fullArgs = new String[] {
         IcapScanFile.MODEL_ARG, "DEFAULT_MODEL", IcapScanFile.FILE_ARG,
         file.getAbsolutePath(), "-to", "127.0.0.1", "-port", "9999",
-        "-previewSize", "2048", "-blockSize", "2048", "-receiveSize",
-        "2048", "-maxSize", "100000", "-errorDelete", "-keyPreview", "Methods",
+        "-previewSize", "2048", "-blockSize", "2048", "-receiveSize", "2048",
+        "-maxSize", "100000", "-errorDelete", "-keyPreview", "Methods",
         "-stringPreview", "RESPMOD", "-key204", "Options-TTL", "-string204",
         "600", "-stringHttp",
         "This is data that was returned by an origin server"

--- a/WaarpR66/src/main/java/org/waarp/openr66/client/AbstractTransfer.java
+++ b/WaarpR66/src/main/java/org/waarp/openr66/client/AbstractTransfer.java
@@ -91,7 +91,7 @@ public abstract class AbstractTransfer implements Runnable {
   protected AbstractTransfer(Class<?> clasz, R66Future future,
                              TransferArgs transferArgs) {
     this(clasz, future, transferArgs.getFilename(), transferArgs.getRulename(),
-         transferArgs.getFileinfo(), transferArgs.isMD5(),
+         transferArgs.getTransferInfo(), transferArgs.isMD5(),
          transferArgs.getRemoteHost(), transferArgs.getBlockSize(),
          transferArgs.getId(), transferArgs.getStartTime());
   }
@@ -101,23 +101,23 @@ public abstract class AbstractTransfer implements Runnable {
    * @param future
    * @param filename
    * @param rulename
-   * @param fileinfo
+   * @param transferInfo
    * @param isMD5
    * @param remoteHost
    * @param blocksize
    * @param id
    */
   protected AbstractTransfer(Class<?> clasz, R66Future future, String filename,
-                             String rulename, String fileinfo, boolean isMD5,
-                             String remoteHost, int blocksize, long id,
-                             Timestamp timestart) {
+                             String rulename, String transferInfo,
+                             boolean isMD5, String remoteHost, int blocksize,
+                             long id, Timestamp timestart) {
     if (logger == null) {
       logger = WaarpLoggerFactory.getLogger(clasz);
     }
     this.future = future;
     this.transferArgs.setFilename(filename);
     this.transferArgs.setRulename(rulename);
-    this.transferArgs.setFileinfo(fileinfo);
+    this.transferArgs.setTransferInfo(transferInfo);
     this.transferArgs.setMD5(isMD5);
     if (Configuration.configuration.getAliases().containsKey(remoteHost)) {
       this.transferArgs.setRemoteHost(
@@ -197,9 +197,9 @@ public abstract class AbstractTransfer implements Runnable {
       }
       // requested
       taskRunner.setSenderByRequestToValidate(true);
-      if (transferArgs.getFileinfo() != null &&
-          !transferArgs.getFileinfo().equals(NO_INFO_ARGS)) {
-        taskRunner.setFileInformation(transferArgs.getFileinfo());
+      if (transferArgs.getTransferInfo() != null &&
+          !transferArgs.getTransferInfo().equals(NO_INFO_ARGS)) {
+        taskRunner.setTransferInfo(transferArgs.getTransferInfo());
       }
       if (transferArgs.getStartTime() != null) {
         taskRunner.setStart(transferArgs.getStartTime());
@@ -239,8 +239,8 @@ public abstract class AbstractTransfer implements Runnable {
           new RequestPacket(transferArgs.getRulename(), mode,
                             transferArgs.getFilename(),
                             transferArgs.getBlockSize(), 0,
-                            transferArgs.getId(), transferArgs.getFileinfo(),
-                            originalSize, sep);
+                            transferArgs.getId(),
+                            transferArgs.getTransferInfo(), originalSize, sep);
       // Not isRecv since it is the requester, so send => isRetrieve is true
       final boolean isRetrieve = !RequestPacket.isRecvMode(request.getMode());
       try {
@@ -262,7 +262,7 @@ public abstract class AbstractTransfer implements Runnable {
   protected static String rhost;
   protected static String localFilename;
   protected static String rule;
-  protected static String fileInfo;
+  protected static String transferInfo;
   protected static boolean ismd5;
   protected static int block = 0x10000; // 64K
   // as
@@ -276,7 +276,7 @@ public abstract class AbstractTransfer implements Runnable {
     rhost = null;
     localFilename = null;
     rule = null;
-    fileInfo = null;
+    transferInfo = null;
     ismd5 = false;
     block = 0x10000; // 64K
     nolog = false;
@@ -320,7 +320,7 @@ public abstract class AbstractTransfer implements Runnable {
     rhost = transferArgsLocal.getRemoteHost();
     localFilename = transferArgsLocal.getFilename();
     rule = transferArgsLocal.getRulename();
-    fileInfo = transferArgsLocal.getFileinfo();
+    transferInfo = transferArgsLocal.getTransferInfo();
     ismd5 = transferArgsLocal.isMD5();
     block = transferArgsLocal.getBlockSize();
     idt = transferArgsLocal.getId();
@@ -339,7 +339,7 @@ public abstract class AbstractTransfer implements Runnable {
    * (-file <arg>     Specify the file path to operate on<br>
    * -rule <arg>))    Specify the Rule<br>
    * [-block <arg>]   Specify the block size<br>
-   * [-follow]        Specify the transfer should integrate a FOLLOW id<br>
+   * [-nofollow]      Specify the transfer should not integrate a FOLLOW id<br>
    * [-md5]           Specify the option to have a hash computed for the
    * transfer<br>
    * [-delay <arg>]   Specify the delay time as an epoch time or '+' a delay in ms<br>

--- a/WaarpR66/src/main/java/org/waarp/openr66/client/DirectTransfer.java
+++ b/WaarpR66/src/main/java/org/waarp/openr66/client/DirectTransfer.java
@@ -51,11 +51,11 @@ public class DirectTransfer extends AbstractTransfer {
   protected boolean limitRetryConnection = true;
 
   public DirectTransfer(R66Future future, String remoteHost, String filename,
-                        String rulename, String fileinfo, boolean isMD5,
+                        String rulename, String transferInfo, boolean isMD5,
                         int blocksize, long id,
                         NetworkTransaction networkTransaction) {
     // no starttime since it is direct (blocking request, no delay)
-    super(DirectTransfer.class, future, filename, rulename, fileinfo, isMD5,
+    super(DirectTransfer.class, future, filename, rulename, transferInfo, isMD5,
           remoteHost, blocksize, id, null);
     this.networkTransaction = networkTransaction;
   }
@@ -180,7 +180,7 @@ public class DirectTransfer extends AbstractTransfer {
     final NetworkTransaction networkTransaction = new NetworkTransaction();
     try {
       final DirectTransfer transaction =
-          new DirectTransfer(future, rhost, localFilename, rule, fileInfo,
+          new DirectTransfer(future, rhost, localFilename, rule, transferInfo,
                              ismd5, block, idt, networkTransaction);
       transaction.normalInfoAsWarn = snormalInfoAsWarn;
       logger.debug(

--- a/WaarpR66/src/main/java/org/waarp/openr66/client/DirectTransfer.java
+++ b/WaarpR66/src/main/java/org/waarp/openr66/client/DirectTransfer.java
@@ -183,8 +183,8 @@ public class DirectTransfer extends AbstractTransfer {
           new DirectTransfer(future, rhost, localFilename, rule, fileInfo,
                              ismd5, block, idt, networkTransaction);
       transaction.normalInfoAsWarn = snormalInfoAsWarn;
-      logger
-          .debug("rhost: " + rhost + ':' + transaction.transferArgs.remoteHost);
+      logger.debug(
+          "rhost: " + rhost + ':' + transaction.transferArgs.getRemoteHost());
       transaction.run();
       future.awaitOrInterruptible();
       final long time2 = System.currentTimeMillis();

--- a/WaarpR66/src/main/java/org/waarp/openr66/client/DirectTransfer.java
+++ b/WaarpR66/src/main/java/org/waarp/openr66/client/DirectTransfer.java
@@ -183,7 +183,8 @@ public class DirectTransfer extends AbstractTransfer {
           new DirectTransfer(future, rhost, localFilename, rule, fileInfo,
                              ismd5, block, idt, networkTransaction);
       transaction.normalInfoAsWarn = snormalInfoAsWarn;
-      logger.debug("rhost: " + rhost + ':' + transaction.remoteHost);
+      logger
+          .debug("rhost: " + rhost + ':' + transaction.transferArgs.remoteHost);
       transaction.run();
       future.awaitOrInterruptible();
       final long time2 = System.currentTimeMillis();

--- a/WaarpR66/src/main/java/org/waarp/openr66/client/MultipleDirectTransfer.java
+++ b/WaarpR66/src/main/java/org/waarp/openr66/client/MultipleDirectTransfer.java
@@ -74,14 +74,14 @@ public class MultipleDirectTransfer extends DirectTransfer {
 
   @Override
   public void run() {
-    final String[] localfilenames = filename.split(",");
-    final String[] rhosts = remoteHost.split(",");
+    final String[] localfilenames = transferArgs.filename.split(",");
+    final String[] rhosts = transferArgs.remoteHost.split(",");
     boolean inError = false;
     R66Result resultError = null;
     // first check if filenames contains wildcards
     DbRule dbrule;
     try {
-      dbrule = new DbRule(rulename);
+      dbrule = new DbRule(transferArgs.rulename);
     } catch (final WaarpDatabaseException e1) {
       logger.error(Messages.getString("Transfer.18"), e1); //$NON-NLS-1$
       future.setFailure(e1);
@@ -106,10 +106,13 @@ public class MultipleDirectTransfer extends DirectTransfer {
             final long time1 = System.currentTimeMillis();
             final R66Future future = new R66Future(true);
             final DirectTransfer transaction =
-                new DirectTransfer(future, host, filename, rulename, fileinfo,
-                                   isMD5, blocksize, id, networkTransaction);
+                new DirectTransfer(future, host, filename,
+                                   transferArgs.rulename, transferArgs.fileinfo,
+                                   transferArgs.isMD5, transferArgs.blocksize,
+                                   transferArgs.id, networkTransaction);
             transaction.normalInfoAsWarn = normalInfoAsWarn;
-            logger.debug("rhost: " + host + ':' + transaction.remoteHost);
+            logger.debug(
+                "rhost: " + host + ':' + transaction.transferArgs.remoteHost);
             transaction.run();
             future.awaitOrInterruptible();
             final long time2 = System.currentTimeMillis();

--- a/WaarpR66/src/main/java/org/waarp/openr66/client/MultipleDirectTransfer.java
+++ b/WaarpR66/src/main/java/org/waarp/openr66/client/MultipleDirectTransfer.java
@@ -108,7 +108,7 @@ public class MultipleDirectTransfer extends DirectTransfer {
             final DirectTransfer transaction =
                 new DirectTransfer(future, host, filename,
                                    transferArgs.getRulename(),
-                                   transferArgs.getFileinfo(),
+                                   transferArgs.getTransferInfo(),
                                    transferArgs.isMD5(),
                                    transferArgs.getBlockSize(),
                                    transferArgs.getId(), networkTransaction);
@@ -203,7 +203,7 @@ public class MultipleDirectTransfer extends DirectTransfer {
       final long time1 = System.currentTimeMillis();
       final MultipleDirectTransfer multipleDirectTransfer =
           new MultipleDirectTransfer(future, rhost, localFilename, rule,
-                                     fileInfo, ismd5, block, idt,
+                                     transferInfo, ismd5, block, idt,
                                      networkTransaction);
       multipleDirectTransfer.normalInfoAsWarn = snormalInfoAsWarn;
       multipleDirectTransfer.run();

--- a/WaarpR66/src/main/java/org/waarp/openr66/client/MultipleDirectTransfer.java
+++ b/WaarpR66/src/main/java/org/waarp/openr66/client/MultipleDirectTransfer.java
@@ -74,14 +74,14 @@ public class MultipleDirectTransfer extends DirectTransfer {
 
   @Override
   public void run() {
-    final String[] localfilenames = transferArgs.filename.split(",");
-    final String[] rhosts = transferArgs.remoteHost.split(",");
+    final String[] localfilenames = transferArgs.getFilename().split(",");
+    final String[] rhosts = transferArgs.getRemoteHost().split(",");
     boolean inError = false;
     R66Result resultError = null;
     // first check if filenames contains wildcards
     DbRule dbrule;
     try {
-      dbrule = new DbRule(transferArgs.rulename);
+      dbrule = new DbRule(transferArgs.getRulename());
     } catch (final WaarpDatabaseException e1) {
       logger.error(Messages.getString("Transfer.18"), e1); //$NON-NLS-1$
       future.setFailure(e1);
@@ -107,12 +107,14 @@ public class MultipleDirectTransfer extends DirectTransfer {
             final R66Future future = new R66Future(true);
             final DirectTransfer transaction =
                 new DirectTransfer(future, host, filename,
-                                   transferArgs.rulename, transferArgs.fileinfo,
-                                   transferArgs.isMD5, transferArgs.blocksize,
-                                   transferArgs.id, networkTransaction);
+                                   transferArgs.getRulename(),
+                                   transferArgs.getFileinfo(),
+                                   transferArgs.isMD5(),
+                                   transferArgs.getBlockSize(),
+                                   transferArgs.getId(), networkTransaction);
             transaction.normalInfoAsWarn = normalInfoAsWarn;
-            logger.debug(
-                "rhost: " + host + ':' + transaction.transferArgs.remoteHost);
+            logger.debug("rhost: " + host + ':' +
+                         transaction.transferArgs.getRemoteHost());
             transaction.run();
             future.awaitOrInterruptible();
             final long time2 = System.currentTimeMillis();

--- a/WaarpR66/src/main/java/org/waarp/openr66/client/MultipleSubmitTransfer.java
+++ b/WaarpR66/src/main/java/org/waarp/openr66/client/MultipleSubmitTransfer.java
@@ -128,7 +128,7 @@ public class MultipleSubmitTransfer extends SubmitTransfer {
             final SubmitTransfer transaction =
                 new SubmitTransfer(future, host, filename,
                                    transferArgs.getRulename(),
-                                   transferArgs.getFileinfo(),
+                                   transferArgs.getTransferInfo(),
                                    transferArgs.isMD5(),
                                    transferArgs.getBlockSize(),
                                    transferArgs.getId(),
@@ -213,8 +213,8 @@ public class MultipleSubmitTransfer extends SubmitTransfer {
       final R66Future future = new R66Future(true);
       final MultipleSubmitTransfer transaction =
           new MultipleSubmitTransfer(future, rhost, localFilename, rule,
-                                     fileInfo, ismd5, block, idt, ttimestart,
-                                     networkTransaction);
+                                     transferInfo, ismd5, block, idt,
+                                     ttimestart, networkTransaction);
       transaction.normalInfoAsWarn = snormalInfoAsWarn;
       transaction.run();
       future.awaitOrInterruptible();

--- a/WaarpR66/src/main/java/org/waarp/openr66/client/MultipleSubmitTransfer.java
+++ b/WaarpR66/src/main/java/org/waarp/openr66/client/MultipleSubmitTransfer.java
@@ -81,17 +81,17 @@ public class MultipleSubmitTransfer extends SubmitTransfer {
 
   @Override
   public void run() {
-    final String[] localfilenames = filename.split(",");
-    final String[] rhosts = remoteHost.split(",");
+    final String[] localfilenames = transferArgs.filename.split(",");
+    final String[] rhosts = transferArgs.remoteHost.split(",");
     R66Result resultError = null;
 
     // first check if filenames contains wildcards
     DbRule dbrule = null;
     try {
-      dbrule = new DbRule(rulename);
+      dbrule = new DbRule(transferArgs.rulename);
     } catch (final WaarpDatabaseException e) {
-      logger.error(
-          Messages.getString("SubmitTransfer.2") + rulename); //$NON-NLS-1$
+      logger.error(Messages.getString("SubmitTransfer.2") +
+                   transferArgs.rulename); //$NON-NLS-1$
       if (DetectionUtils.isJunit()) {
         return;
       }
@@ -126,8 +126,10 @@ public class MultipleSubmitTransfer extends SubmitTransfer {
           if (filename != null && !filename.isEmpty()) {
             final R66Future future = new R66Future(true);
             final SubmitTransfer transaction =
-                new SubmitTransfer(future, host, filename, rulename, fileinfo,
-                                   isMD5, blocksize, id, startTime);
+                new SubmitTransfer(future, host, filename,
+                                   transferArgs.rulename, transferArgs.fileinfo,
+                                   transferArgs.isMD5, transferArgs.blocksize,
+                                   transferArgs.id, transferArgs.startTime);
             transaction.normalInfoAsWarn = normalInfoAsWarn;
             transaction.run();
             future.awaitOrInterruptible();

--- a/WaarpR66/src/main/java/org/waarp/openr66/client/MultipleSubmitTransfer.java
+++ b/WaarpR66/src/main/java/org/waarp/openr66/client/MultipleSubmitTransfer.java
@@ -81,17 +81,17 @@ public class MultipleSubmitTransfer extends SubmitTransfer {
 
   @Override
   public void run() {
-    final String[] localfilenames = transferArgs.filename.split(",");
-    final String[] rhosts = transferArgs.remoteHost.split(",");
+    final String[] localfilenames = transferArgs.getFilename().split(",");
+    final String[] rhosts = transferArgs.getRemoteHost().split(",");
     R66Result resultError = null;
 
     // first check if filenames contains wildcards
     DbRule dbrule = null;
     try {
-      dbrule = new DbRule(transferArgs.rulename);
+      dbrule = new DbRule(transferArgs.getRulename());
     } catch (final WaarpDatabaseException e) {
       logger.error(Messages.getString("SubmitTransfer.2") +
-                   transferArgs.rulename); //$NON-NLS-1$
+                   transferArgs.getRulename()); //$NON-NLS-1$
       if (DetectionUtils.isJunit()) {
         return;
       }
@@ -127,9 +127,12 @@ public class MultipleSubmitTransfer extends SubmitTransfer {
             final R66Future future = new R66Future(true);
             final SubmitTransfer transaction =
                 new SubmitTransfer(future, host, filename,
-                                   transferArgs.rulename, transferArgs.fileinfo,
-                                   transferArgs.isMD5, transferArgs.blocksize,
-                                   transferArgs.id, transferArgs.startTime);
+                                   transferArgs.getRulename(),
+                                   transferArgs.getFileinfo(),
+                                   transferArgs.isMD5(),
+                                   transferArgs.getBlockSize(),
+                                   transferArgs.getId(),
+                                   transferArgs.getStartTime());
             transaction.normalInfoAsWarn = normalInfoAsWarn;
             transaction.run();
             future.awaitOrInterruptible();

--- a/WaarpR66/src/main/java/org/waarp/openr66/client/ProgressBarTransfer.java
+++ b/WaarpR66/src/main/java/org/waarp/openr66/client/ProgressBarTransfer.java
@@ -91,7 +91,7 @@ public abstract class ProgressBarTransfer extends AbstractTransfer {
     final DbTaskRunner taskRunner = initRequest();
     if (taskRunner == null) {
       // already an error from there
-      lastCallBack(false, 0, transferArgs.blocksize);
+      lastCallBack(false, 0, transferArgs.getBlockSize());
       return;
     }
     final ClientRunner runner =

--- a/WaarpR66/src/main/java/org/waarp/openr66/client/ProgressBarTransfer.java
+++ b/WaarpR66/src/main/java/org/waarp/openr66/client/ProgressBarTransfer.java
@@ -91,7 +91,7 @@ public abstract class ProgressBarTransfer extends AbstractTransfer {
     final DbTaskRunner taskRunner = initRequest();
     if (taskRunner == null) {
       // already an error from there
-      lastCallBack(false, 0, blocksize);
+      lastCallBack(false, 0, transferArgs.blocksize);
       return;
     }
     final ClientRunner runner =

--- a/WaarpR66/src/main/java/org/waarp/openr66/client/SendThroughClient.java
+++ b/WaarpR66/src/main/java/org/waarp/openr66/client/SendThroughClient.java
@@ -156,9 +156,9 @@ public abstract class SendThroughClient extends AbstractTransfer {
     }
     DbRule rule;
     try {
-      rule = new DbRule(rulename);
+      rule = new DbRule(transferArgs.rulename);
     } catch (final WaarpDatabaseException e) {
-      logger.error("Cannot get Rule: " + rulename, e);
+      logger.error("Cannot get Rule: " + transferArgs.rulename, e);
       future.setResult(
           new R66Result(new OpenR66DatabaseGlobalException(e), null, true,
                         ErrorCode.Internal, null));
@@ -166,20 +166,23 @@ public abstract class SendThroughClient extends AbstractTransfer {
       return false;
     }
     int mode = rule.getMode();
-    if (isMD5) {
+    if (transferArgs.isMD5) {
       mode = RequestPacket.getModeMD5(mode);
     }
-    final String sep = PartnerConfiguration.getSeparator(remoteHost);
+    final String sep =
+        PartnerConfiguration.getSeparator(transferArgs.remoteHost);
     final RequestPacket request =
-        new RequestPacket(rulename, mode, filename, blocksize, 0, id, fileinfo,
-                          -1, sep);
+        new RequestPacket(transferArgs.rulename, mode, transferArgs.filename,
+                          transferArgs.blocksize, 0, transferArgs.id,
+                          transferArgs.fileinfo, -1, sep);
     // Not isRecv since it is the requester, so send => isSender is true
     final boolean isSender = true;
     try {
       try {
         // no starttime since immediate
         taskRunner =
-            new DbTaskRunner(rule, isSender, request, remoteHost, null);
+            new DbTaskRunner(rule, isSender, request, transferArgs.remoteHost,
+                             null);
       } catch (final WaarpDatabaseException e) {
         logger.error("Cannot get task", e);
         future.setResult(

--- a/WaarpR66/src/main/java/org/waarp/openr66/client/SendThroughClient.java
+++ b/WaarpR66/src/main/java/org/waarp/openr66/client/SendThroughClient.java
@@ -175,7 +175,7 @@ public abstract class SendThroughClient extends AbstractTransfer {
         new RequestPacket(transferArgs.getRulename(), mode,
                           transferArgs.getFilename(),
                           transferArgs.getBlockSize(), 0, transferArgs.getId(),
-                          transferArgs.getFileinfo(), -1, sep);
+                          transferArgs.getTransferInfo(), -1, sep);
     // Not isRecv since it is the requester, so send => isSender is true
     final boolean isSender = true;
     try {

--- a/WaarpR66/src/main/java/org/waarp/openr66/client/SendThroughClient.java
+++ b/WaarpR66/src/main/java/org/waarp/openr66/client/SendThroughClient.java
@@ -156,9 +156,9 @@ public abstract class SendThroughClient extends AbstractTransfer {
     }
     DbRule rule;
     try {
-      rule = new DbRule(transferArgs.rulename);
+      rule = new DbRule(transferArgs.getRulename());
     } catch (final WaarpDatabaseException e) {
-      logger.error("Cannot get Rule: " + transferArgs.rulename, e);
+      logger.error("Cannot get Rule: " + transferArgs.getRulename(), e);
       future.setResult(
           new R66Result(new OpenR66DatabaseGlobalException(e), null, true,
                         ErrorCode.Internal, null));
@@ -166,23 +166,23 @@ public abstract class SendThroughClient extends AbstractTransfer {
       return false;
     }
     int mode = rule.getMode();
-    if (transferArgs.isMD5) {
+    if (transferArgs.isMD5()) {
       mode = RequestPacket.getModeMD5(mode);
     }
     final String sep =
-        PartnerConfiguration.getSeparator(transferArgs.remoteHost);
+        PartnerConfiguration.getSeparator(transferArgs.getRemoteHost());
     final RequestPacket request =
-        new RequestPacket(transferArgs.rulename, mode, transferArgs.filename,
-                          transferArgs.blocksize, 0, transferArgs.id,
-                          transferArgs.fileinfo, -1, sep);
+        new RequestPacket(transferArgs.getRulename(), mode,
+                          transferArgs.getFilename(),
+                          transferArgs.getBlockSize(), 0, transferArgs.getId(),
+                          transferArgs.getFileinfo(), -1, sep);
     // Not isRecv since it is the requester, so send => isSender is true
     final boolean isSender = true;
     try {
       try {
         // no starttime since immediate
-        taskRunner =
-            new DbTaskRunner(rule, isSender, request, transferArgs.remoteHost,
-                             null);
+        taskRunner = new DbTaskRunner(rule, isSender, request,
+                                      transferArgs.getRemoteHost(), null);
       } catch (final WaarpDatabaseException e) {
         logger.error("Cannot get task", e);
         future.setResult(

--- a/WaarpR66/src/main/java/org/waarp/openr66/client/SubmitTransfer.java
+++ b/WaarpR66/src/main/java/org/waarp/openr66/client/SubmitTransfer.java
@@ -68,7 +68,7 @@ public class SubmitTransfer extends AbstractTransfer {
       future.setFailure(result.getException());
       return;
     }
-    if (id != ILLEGALVALUE) {
+    if (transferArgs.id != ILLEGALVALUE) {
       // Resubmit call, some checks are needed
       if (!taskRunner.restart(true)) {
         // cannot be done from there => must be done through IHM

--- a/WaarpR66/src/main/java/org/waarp/openr66/client/SubmitTransfer.java
+++ b/WaarpR66/src/main/java/org/waarp/openr66/client/SubmitTransfer.java
@@ -44,9 +44,9 @@ import static org.waarp.common.database.DbConstant.*;
 public class SubmitTransfer extends AbstractTransfer {
 
   public SubmitTransfer(R66Future future, String remoteHost, String filename,
-                        String rulename, String fileinfo, boolean isMD5,
+                        String rulename, String transferInfo, boolean isMD5,
                         int blocksize, long id, Timestamp starttime) {
-    super(SubmitTransfer.class, future, filename, rulename, fileinfo, isMD5,
+    super(SubmitTransfer.class, future, filename, rulename, transferInfo, isMD5,
           remoteHost, blocksize, id, starttime);
   }
 
@@ -141,8 +141,8 @@ public class SubmitTransfer extends AbstractTransfer {
     }
     final R66Future future = new R66Future(true);
     final SubmitTransfer transaction =
-        new SubmitTransfer(future, rhost, localFilename, rule, fileInfo, ismd5,
-                           block, idt, ttimestart);
+        new SubmitTransfer(future, rhost, localFilename, rule, transferInfo,
+                           ismd5, block, idt, ttimestart);
     transaction.normalInfoAsWarn = snormalInfoAsWarn;
     transaction.run();
     future.awaitOrInterruptible();

--- a/WaarpR66/src/main/java/org/waarp/openr66/client/SubmitTransfer.java
+++ b/WaarpR66/src/main/java/org/waarp/openr66/client/SubmitTransfer.java
@@ -68,7 +68,7 @@ public class SubmitTransfer extends AbstractTransfer {
       future.setFailure(result.getException());
       return;
     }
-    if (transferArgs.id != ILLEGALVALUE) {
+    if (transferArgs.getId() != ILLEGALVALUE) {
       // Resubmit call, some checks are needed
       if (!taskRunner.restart(true)) {
         // cannot be done from there => must be done through IHM

--- a/WaarpR66/src/main/java/org/waarp/openr66/client/TransferArgs.java
+++ b/WaarpR66/src/main/java/org/waarp/openr66/client/TransferArgs.java
@@ -1,0 +1,423 @@
+/*
+ * This file is part of Waarp Project (named also Waarp or GG).
+ *
+ *  Copyright (c) 2019, Waarp SAS, and individual contributors by the @author
+ *  tags. See the COPYRIGHT.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ *  All Waarp Project is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * Waarp is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ * Waarp . If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.waarp.openr66.client;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.OptionGroup;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+import org.waarp.common.database.exception.WaarpDatabaseException;
+import org.waarp.common.database.exception.WaarpDatabaseNoDataException;
+import org.waarp.common.guid.LongUuid;
+import org.waarp.common.logging.SysErrLogger;
+import org.waarp.common.logging.WaarpLogger;
+import org.waarp.common.logging.WaarpLoggerFactory;
+import org.waarp.openr66.database.data.DbTaskRunner;
+import org.waarp.openr66.protocol.configuration.Configuration;
+import org.waarp.openr66.protocol.configuration.Messages;
+
+import java.sql.Timestamp;
+import java.text.SimpleDateFormat;
+import java.util.Arrays;
+import java.util.Date;
+
+import static org.waarp.common.database.DbConstant.*;
+
+/**
+ * Transfer arguments:<br>
+ * <br>
+ * -to <arg>        Specify the requested Host<br>
+ * (-id <arg>|      Specify the id of transfer<br>
+ * (-file <arg>     Specify the file path to operate on<br>
+ * -rule <arg>))    Specify the Rule<br>
+ * [-block <arg>]   Specify the block size<br>
+ * [-follow]        Specify the transfer should integrate a FOLLOW id<br>
+ * [-md5]           Specify the option to have a hash computed for the
+ * transfer<br>
+ * [-delay <arg>]   Specify the delay time as an epoch time or '+' a delay in ms<br>
+ * [-start <arg>]   Specify the start time as yyyyMMddHHmmss<br>
+ * [-info <arg>)    Specify the transfer information (generally in last position)<br>
+ * [-nolog]         Specify to not log anything included database once the
+ * transfer is done<br>
+ * [-notlogWarn |   Specify to log final result as Info if OK<br>
+ * -logWarn]        Specify to log final result as Warn if OK<br>
+ */
+public class TransferArgs {
+  private static final WaarpLogger logger =
+      WaarpLoggerFactory.getLogger(TransferArgs.class);
+
+  private static final String FILE = "file";
+  public static final String FILE_ARG = "-" + FILE;
+  private static final Option FILE_OPTION =
+      Option.builder(FILE).required(false).hasArg(true)
+            .desc("Specify the file path to operate on").build();
+  private static final String TO = "to";
+  public static final String TO_ARG = "-" + TO;
+  private static final Option TO_OPTION =
+      Option.builder(TO).required(true).hasArg(true)
+            .desc("Specify the requested Host").build();
+  private static final String RULE = "rule";
+  public static final String RULE_ARG = "-" + RULE;
+  private static final Option RULE_OPTION =
+      Option.builder(RULE).required(false).hasArg(true).desc("Specify the Rule")
+            .build();
+  private static final String ID = "id";
+  public static final String ID_ARG = "-" + ID;
+  private static final Option ID_OPTION =
+      Option.builder(ID).required(false).hasArg(true)
+            .desc("Specify the id of transfer").build();
+  private static final String FOLLOW = "follow";
+  public static final String FOLLOW_ARG = "-" + FOLLOW;
+  private static final Option FOLLOW_OPTION =
+      Option.builder(FOLLOW).required(false).hasArg(false)
+            .desc("Specify the transfer should integrate a FOLLOW id").build();
+  public static final String FOLLOWARGJSON = "{'follow':";
+  private static final String INFO = "info";
+  public static final String INFO_ARG = "-" + INFO;
+  private static final Option INFO_OPTION =
+      Option.builder(INFO).required(false).hasArg(true)
+            .desc("Specify the transfer information").build();
+  private static final String HASH = "md5";
+  public static final String HASH_ARG = "-" + HASH;
+  private static final Option HASH_OPTION =
+      Option.builder(HASH).required(false).hasArg(false)
+            .desc("Specify the option to have a hash computed for the transfer")
+            .build();
+  private static final String BLOCK = "block";
+  public static final String BLOCK_ARG = "-" + BLOCK;
+  private static final Option BLOCK_OPTION =
+      Option.builder(BLOCK).required(false).hasArg(true)
+            .desc("Specify the block size").build();
+  private static final String START = "start";
+  public static final String START_ARG = "-" + START;
+  private static final Option START_OPTION =
+      Option.builder(START).required(false).hasArg(true)
+            .desc("Specify the start time as yyyyMMddHHmmss").build();
+  private static final String DELAY = "delay";
+  public static final String DELAY_ARG = "-" + DELAY;
+  private static final Option DELAY_OPTION =
+      Option.builder(DELAY).required(false).hasArg(true).desc(
+          "Specify the delay time as an epoch time or '+' a delay in ms")
+            .build();
+
+  private static final String LOGWARN = "logWarn";
+  public static final String LOGWARN_ARG = "-" + LOGWARN;
+  private static final Option LOGWARN_OPTION =
+      Option.builder(LOGWARN).required(false).hasArg(false)
+            .desc("Specify to log final result as Warn if OK").build();
+  private static final String NOTLOGWARN = "notlogWarn";
+  public static final String NOTLOGWARN_ARG = "-" + NOTLOGWARN;
+  private static final Option NOTLOGWARN_OPTION =
+      Option.builder(NOTLOGWARN).required(false).hasArg(false)
+            .desc("Specify to log final result as Info if OK").build();
+
+  private static final String NOTLOG = "nolog";
+  public static final String NOTLOG_ARG = "-" + NOTLOG;
+  private static final Option NOTLOG_OPTION =
+      Option.builder(NOTLOG).required(false).hasArg(false).desc(
+          "Specify to not log anything included database once the " +
+          "transfer is done").build();
+
+  private static final OptionGroup LOGWARN_OPTIONS =
+      new OptionGroup().addOption(LOGWARN_OPTION).addOption(NOTLOGWARN_OPTION);
+  private static final Options TRANSFER_OPTIONS =
+      new Options().addOption(FILE_OPTION).addOption(TO_OPTION)
+                   .addOption(FOLLOW_OPTION).addOption(RULE_OPTION)
+                   .addOption(ID_OPTION).addOption(INFO_OPTION)
+                   .addOption(HASH_OPTION).addOption(BLOCK_OPTION)
+                   .addOption(START_OPTION).addOption(DELAY_OPTION)
+                   .addOption(NOTLOG_OPTION).addOptionGroup(LOGWARN_OPTIONS);
+
+  public static final String SEPARATOR_SEND = "--";
+
+
+  /**
+   * Print to standard output the help of this command
+   */
+  public static void printHelp() {
+    HelpFormatter formatter = new HelpFormatter();
+    formatter.printHelp("Transfer", TRANSFER_OPTIONS);
+  }
+
+  /**
+   * Analyze the parameters according to TransferArgs options
+   * <br><br>
+   * Transfer arguments:<br>
+   * <br>
+   * -to <arg>        Specify the requested Host<br>
+   * (-id <arg>|      Specify the id of transfer<br>
+   * (-file <arg>     Specify the file path to operate on<br>
+   * -rule <arg>))    Specify the Rule<br>
+   * [-block <arg>]   Specify the block size<br>
+   * [-follow]        Specify the transfer should integrate a FOLLOW id<br>
+   * [-md5]           Specify the option to have a hash computed for the
+   * transfer<br>
+   * [-delay <arg>]   Specify the delay time as an epoch time or '+' a delay in ms<br>
+   * [-start <arg>]   Specify the start time as yyyyMMddHHmmss<br>
+   * [-info <arg>)    Specify the transfer information (generally in last position)<br>
+   * [-nolog]         Specify to not log anything included database once the
+   * transfer is done<br>
+   * [-notlogWarn |   Specify to log final result as Info if OK<br>
+   * -logWarn]        Specify to log final result as Warn if OK<br>
+   *
+   * @param rank the rank to analyze from
+   * @param args the argument to analyze
+   * @param analyseFollow if True, will check follow possible argument in info
+   *
+   * @return the TransferArgs or null if an error occurs
+   */
+  public static TransferArgs getParamsInternal(final int rank,
+                                               final String[] args,
+                                               boolean analyseFollow) {
+    if (args == null || args.length == 0) {
+      logger.error("Arguments cannot be empty or null");
+      return null;
+    }
+    String[] realArgs =
+        rank == 0? args : Arrays.copyOfRange(args, rank, args.length);
+    for (int i = rank; i < args.length; i++) {
+      if (SEPARATOR_SEND.equals(args[i])) {
+        realArgs = Arrays.copyOfRange(args, rank, i);
+        break;
+      }
+    }
+
+    // Now set default values from configuration
+    TransferArgs transferArgs1 = new TransferArgs();
+    transferArgs1.blocksize = Configuration.configuration.getBlockSize();
+
+    CommandLineParser parser = new DefaultParser();
+    try {
+      CommandLine cmd = parser.parse(TRANSFER_OPTIONS, realArgs, true);
+      if (cmd.hasOption(TO)) {
+        transferArgs1.remoteHost = cmd.getOptionValue(TO);
+        if (Configuration.configuration.getAliases()
+                                       .containsKey(transferArgs1.remoteHost)) {
+          transferArgs1.remoteHost = Configuration.configuration.getAliases()
+                                                                .get(
+                                                                    transferArgs1.remoteHost);
+        }
+      }
+      if (cmd.hasOption(FILE)) {
+        transferArgs1.filename = cmd.getOptionValue(FILE);
+        transferArgs1.filename = transferArgs1.filename.replace('§', '*');
+      }
+      if (cmd.hasOption(RULE)) {
+        transferArgs1.rulename = cmd.getOptionValue(RULE);
+      }
+      if (cmd.hasOption(ID)) {
+        try {
+          transferArgs1.id = Long.parseLong(cmd.getOptionValue(ID));
+        } catch (NumberFormatException ignored) {
+          SysErrLogger.FAKE_LOGGER.ignoreLog(ignored);
+          logger.error(Messages.getString("AbstractTransfer.20") + " id");
+          //$NON-NLS-1$
+          return null;
+        }
+      }
+      if (cmd.hasOption(START)) {
+        Date date;
+        final SimpleDateFormat dateFormat =
+            new SimpleDateFormat("yyyyMMddHHmmss");
+        try {
+          date = dateFormat.parse(cmd.getOptionValue(START));
+          transferArgs1.startTime = new Timestamp(date.getTime());
+        } catch (java.text.ParseException ignored) {
+          SysErrLogger.FAKE_LOGGER.ignoreLog(ignored);
+          logger
+              .error(Messages.getString("AbstractTransfer.20") + " StartTime");
+          //$NON-NLS-1$
+          return null;
+        }
+      }
+      if (cmd.hasOption(DELAY)) {
+        String delay = cmd.getOptionValue(DELAY);
+        try {
+          if (delay.charAt(0) == '+') {
+            transferArgs1.startTime = new Timestamp(System.currentTimeMillis() +
+                                                    Long.parseLong(
+                                                        delay.substring(1)));
+          } else {
+            transferArgs1.startTime = new Timestamp(Long.parseLong(delay));
+          }
+        } catch (NumberFormatException ignored) {
+          SysErrLogger.FAKE_LOGGER.ignoreLog(ignored);
+          logger.error(Messages.getString("AbstractTransfer.20") + " Delay");
+          //$NON-NLS-1$
+          return null;
+        }
+      }
+      if (cmd.hasOption(FOLLOW)) {
+        transferArgs1.follow = "";
+      }
+      if (cmd.hasOption(INFO)) {
+        transferArgs1.fileinfo = cmd.getOptionValue(INFO);
+      }
+      if (cmd.hasOption(HASH)) {
+        transferArgs1.isMD5 = true;
+      }
+      if (cmd.hasOption(BLOCK)) {
+        try {
+          transferArgs1.blocksize = Integer.parseInt(cmd.getOptionValue(BLOCK));
+        } catch (NumberFormatException ignored) {
+          SysErrLogger.FAKE_LOGGER.ignoreLog(ignored);
+          logger.error(Messages.getString("AbstractTransfer.20") + " block");
+          //$NON-NLS-1$
+          return null;
+        }
+        if (transferArgs1.blocksize < 100) {
+          logger.error(Messages.getString("AbstractTransfer.1") +
+                       transferArgs1.blocksize);
+          //$NON-NLS-1$
+          return null;
+        }
+      }
+      if (cmd.hasOption(LOGWARN)) {
+        transferArgs1.normalInfoAsWarn = true;
+      }
+      if (cmd.hasOption(NOTLOGWARN)) {
+        transferArgs1.normalInfoAsWarn = false;
+      }
+      if (cmd.hasOption(NOTLOG)) {
+        transferArgs1.nolog = true;
+      }
+
+    } catch (ParseException e) {
+      printHelp();
+      logger.error("Arguments are incorrect", e);
+      return null;
+    }
+    if (transferArgs1.fileinfo == null) {
+      transferArgs1.fileinfo = AbstractTransfer.NO_INFO_ARGS;
+    }
+    if (analyseFollow) {
+      analyzeFollow(transferArgs1);
+    }
+    if (transferArgs1.remoteHost != null && transferArgs1.rulename != null &&
+        transferArgs1.filename != null) {
+      return transferArgs1;
+    } else if (transferArgs1.id != ILLEGALVALUE &&
+               transferArgs1.remoteHost != null) {
+      try {
+        final DbTaskRunner runner =
+            new DbTaskRunner(transferArgs1.id, transferArgs1.remoteHost);
+        transferArgs1.rulename = runner.getRuleId();
+        transferArgs1.filename = runner.getOriginalFilename();
+        return transferArgs1;
+      } catch (final WaarpDatabaseNoDataException e) {
+        logger.error("No transfer found with this id and partner");
+        logger.error(Messages.getString("AbstractBusinessRequest.NeedMoreArgs",
+                                        "(-to -rule -file | -to -id with " +
+                                        "existing id transfer)")
+                     //$NON-NLS-1$
+            , e);
+        return null;
+      } catch (final WaarpDatabaseException e) {
+        logger.error(Messages.getString("AbstractBusinessRequest.NeedMoreArgs",
+                                        "(-to -rule -file | -to -id) with a " +
+                                        "correct database connexion")
+                     //$NON-NLS-1$
+            , e);
+        return null;
+      }
+    }
+    logger.error(Messages.getString("AbstractBusinessRequest.NeedMoreArgs",
+                                    "(-to -rule -file | -to -id)") +
+                 //$NON-NLS-1$
+                 AbstractTransfer._INFO_ARGS);
+    return null;
+  }
+
+  /**
+   * Get all Info in case of last argument
+   *
+   * @param transferArgs the original TransferArgs
+   * @param rank the rank to start from in args array
+   * @param args the original arguments
+   * @param copiedInfo might be null, original information to copy
+   */
+  public static void getAllInfo(final TransferArgs transferArgs, final int rank,
+                                final String[] args, final String copiedInfo) {
+    if (transferArgs != null) {
+      StringBuilder builder = new StringBuilder();
+      if (copiedInfo != null) {
+        builder.append(copiedInfo);
+      }
+      for (int i = rank; i < args.length; i++) {
+        if (INFO_ARG.equalsIgnoreCase(args[i])) {
+          i++;
+          if (builder.length() == 0) {
+            builder.append(args[i]);
+          } else {
+            builder.append(' ').append(args[i]);
+          }
+          i++;
+          while (i < args.length) {
+            builder.append(' ').append(args[i]);
+            i++;
+          }
+        }
+      }
+      transferArgs.fileinfo = builder.toString();
+      TransferArgs.analyzeFollow(transferArgs);
+    }
+  }
+
+  /**
+   * Analyze Follow option
+   *
+   * @param transferArgs1 the current TransferArgs
+   */
+  public static void analyzeFollow(final TransferArgs transferArgs1) {
+    if (transferArgs1.follow != null && transferArgs1.fileinfo != null) {
+      String[] split = transferArgs1.fileinfo.split(" ");
+      for (int i = 0; i < split.length; i++) {
+        if (FOLLOWARGJSON.equalsIgnoreCase(split[i])) {
+          i++;
+          transferArgs1.follow = split[i].replace("}", "").trim();
+          break;
+        }
+      }
+      if (transferArgs1.follow.isEmpty()) {
+        LongUuid longUuid = new LongUuid();
+        transferArgs1.follow = "" + longUuid.getLong();
+        transferArgs1.fileinfo +=
+            " " + FOLLOWARGJSON + " " + longUuid.getLong() + "}";
+      }
+    }
+  }
+
+  public String filename;
+  public String rulename;
+  public String fileinfo;
+  public boolean isMD5;
+  public String remoteHost;
+  public int blocksize = 0x10000; // 64K
+  public long id = ILLEGALVALUE;
+  public Timestamp startTime;
+  public String follow;
+  public boolean normalInfoAsWarn = true;
+  public boolean nolog = false;
+}

--- a/WaarpR66/src/main/java/org/waarp/openr66/context/task/IcapTask.java
+++ b/WaarpR66/src/main/java/org/waarp/openr66/context/task/IcapTask.java
@@ -57,7 +57,7 @@ import org.waarp.openr66.context.task.exception.OpenR66RunnerErrorException;
  * while still having the
  * possibility to add new informations through "-info":<br>
  * "-file filepath -to requestedHost -rule rule [-md5] [-start yyyyMMddHHmmss or
- * -delay (delay or +delay)] [-follow)
+ * -delay (delay or +delay)] [-nofollow)
  * [-copyinfo] [-info information]" <br>
  * <br>
  * INFO is the only one field that can contains blank character.<br>

--- a/WaarpR66/src/main/java/org/waarp/openr66/context/task/IcapTask.java
+++ b/WaarpR66/src/main/java/org/waarp/openr66/context/task/IcapTask.java
@@ -57,7 +57,7 @@ import org.waarp.openr66.context.task.exception.OpenR66RunnerErrorException;
  * while still having the
  * possibility to add new informations through "-info":<br>
  * "-file filepath -to requestedHost -rule rule [-md5] [-start yyyyMMddHHmmss or
- * -delay (delay or +delay)]
+ * -delay (delay or +delay)] [-follow)
  * [-copyinfo] [-info information]" <br>
  * <br>
  * INFO is the only one field that can contains blank character.<br>

--- a/WaarpR66/src/main/java/org/waarp/openr66/context/task/TaskType.java
+++ b/WaarpR66/src/main/java/org/waarp/openr66/context/task/TaskType.java
@@ -157,8 +157,7 @@ public enum TaskType {
                                  session);
       case ICAP:
         return new IcapTask(argRule, delay,
-                            session.getRunner().getFileInformation(),
-                            session);
+                            session.getRunner().getFileInformation(), session);
       default:
         logger.error(NAME_UNKNOWN + type.name);
         throw new OpenR66RunnerErrorException(UNVALID_TASK + type.name);

--- a/WaarpR66/src/main/java/org/waarp/openr66/context/task/TransferTask.java
+++ b/WaarpR66/src/main/java/org/waarp/openr66/context/task/TransferTask.java
@@ -119,11 +119,13 @@ public class TransferTask extends AbstractExecTask {
     }
     final R66Future future = new R66Future(true);
     final SubmitTransfer transaction =
-        new SubmitTransfer(future, transferArgs.remoteHost,
-                           transferArgs.filename, transferArgs.rulename,
-                           transferArgs.fileinfo, transferArgs.isMD5,
-                           transferArgs.blocksize, DbConstantR66.ILLEGALVALUE,
-                           transferArgs.startTime);
+        new SubmitTransfer(future, transferArgs.getRemoteHost(),
+                           transferArgs.getFilename(),
+                           transferArgs.getRulename(),
+                           transferArgs.getFileinfo(), transferArgs.isMD5(),
+                           transferArgs.getBlockSize(),
+                           DbConstantR66.ILLEGALVALUE,
+                           transferArgs.getStartTime());
     transaction.run();
     future.awaitOrInterruptible();
     final DbTaskRunner runner;
@@ -132,7 +134,7 @@ public class TransferTask extends AbstractExecTask {
       runner = future.getResult().getRunner();
       logger.info(
           "Prepare transfer in     SUCCESS     " + runner.toShortString() +
-          "     <REMOTE>" + transferArgs.remoteHost + "</REMOTE>");
+          "     <REMOTE>" + transferArgs.getRemoteHost() + "</REMOTE>");
       futureCompletion.setSuccess();
     } else {
       if (future.getResult() != null) {
@@ -149,7 +151,7 @@ public class TransferTask extends AbstractExecTask {
         }
         logger.error(
             "Prepare transfer in     FAILURE      " + runner.toShortString() +
-            "     <REMOTE>" + transferArgs.remoteHost + "</REMOTE>",
+            "     <REMOTE>" + transferArgs.getRemoteHost() + "</REMOTE>",
             future.getCause());
       } else {
         if (future.getCause() == null) {

--- a/WaarpR66/src/main/java/org/waarp/openr66/context/task/TransferTask.java
+++ b/WaarpR66/src/main/java/org/waarp/openr66/context/task/TransferTask.java
@@ -53,7 +53,7 @@ import org.waarp.openr66.protocol.utils.R66Future;
  * (-file <arg>     Specify the file path to operate on<br>
  * -rule <arg>))    Specify the Rule<br>
  * [-block <arg>]   Specify the block size<br>
- * [-follow]        Specify the transfer should integrate a FOLLOW id<br>
+ * [-nofollow]      Specify the transfer should not integrate a FOLLOW id<br>
  * [-md5]           Specify the option to have a hash computed for the
  * transfer<br>
  * [-delay <arg>]   Specify the delay time as an epoch time or '+' a delay in ms<br>
@@ -122,7 +122,7 @@ public class TransferTask extends AbstractExecTask {
         new SubmitTransfer(future, transferArgs.getRemoteHost(),
                            transferArgs.getFilename(),
                            transferArgs.getRulename(),
-                           transferArgs.getFileinfo(), transferArgs.isMD5(),
+                           transferArgs.getTransferInfo(), transferArgs.isMD5(),
                            transferArgs.getBlockSize(),
                            DbConstantR66.ILLEGALVALUE,
                            transferArgs.getStartTime());

--- a/WaarpR66/src/main/java/org/waarp/openr66/context/task/javatask/AddDigestJavaTask.java
+++ b/WaarpR66/src/main/java/org/waarp/openr66/context/task/javatask/AddDigestJavaTask.java
@@ -112,6 +112,9 @@ public class AddDigestJavaTask extends AbstractExecJavaTask {
                                .replaceAll(Matcher.quoteReplacement(key));
     }
     session.getRunner().setFileInformation(fileInfo);
+    session.getRunner().setTransferInfo(
+        session.getRunner().getTransferInfo().replaceAll(sDIGEST, key));
+    session.getRunner().addToTransferMap("digest", key);
     try {
       session.getRunner().update();
     } catch (final WaarpDatabaseException e) {

--- a/WaarpR66/src/main/java/org/waarp/openr66/context/task/javatask/AddUuidJavaTask.java
+++ b/WaarpR66/src/main/java/org/waarp/openr66/context/task/javatask/AddUuidJavaTask.java
@@ -87,6 +87,10 @@ public class AddUuidJavaTask extends AbstractExecJavaTask {
                      Matcher.quoteReplacement(uuid.toString()));
     }
     session.getRunner().setFileInformation(fileInfo);
+    session.getRunner().setTransferInfo(session.getRunner().getTransferInfo()
+                                               .replaceAll(sUUID,
+                                                           uuid.toString()));
+    session.getRunner().addToTransferMap("uuid", uuid.toString());
     try {
       session.getRunner().update();
     } catch (final WaarpDatabaseException e) {

--- a/WaarpR66/src/main/java/org/waarp/openr66/dao/xml/XMLTransferDAO.java
+++ b/WaarpR66/src/main/java/org/waarp/openr66/dao/xml/XMLTransferDAO.java
@@ -73,6 +73,7 @@ public class XMLTransferDAO implements TransferDAO {
   public static final String BLOCK_SIZE_FIELD = "blocksz";
   public static final String ORIGINAL_NAME_FIELD = "originalname";
   public static final String FILE_INFO_FIELD = "fileinfo";
+  public static final String TRANSFER_INFO_FIELD = "transferInfo";
   public static final String TRANSFER_MODE_FIELD = "modetrans";
   public static final String START_FIELD = "starttrans";
   public static final String STOP_FIELD = "stoptrans";
@@ -445,6 +446,8 @@ public class XMLTransferDAO implements TransferDAO {
         res.setOriginalName(node.getTextContent());
       } else if (node.getNodeName().equals(FILE_INFO_FIELD)) {
         res.setFileInfo(node.getTextContent());
+      } else if (node.getNodeName().equals(TRANSFER_INFO_FIELD)) {
+        res.setTransferInfo(node.getTextContent());
       } else if (node.getNodeName().equals(IS_MOVED_FIELD)) {
         res.setIsMoved(Boolean.parseBoolean(node.getTextContent()));
       } else if (node.getNodeName().equals(BLOCK_SIZE_FIELD)) {
@@ -495,6 +498,8 @@ public class XMLTransferDAO implements TransferDAO {
         XMLUtils.createNode(doc, REQUESTED_FIELD, transfer.getOriginalName()));
     res.appendChild(
         XMLUtils.createNode(doc, FILE_INFO_FIELD, transfer.getFileInfo()));
+    res.appendChild(XMLUtils.createNode(doc, TRANSFER_INFO_FIELD,
+                                        transfer.getTransferInfo()));
     res.appendChild(XMLUtils.createNode(doc, IS_MOVED_FIELD, Boolean
         .toString(transfer.getIsMoved())));
     res.appendChild(XMLUtils.createNode(doc, BLOCK_SIZE_FIELD, Integer

--- a/WaarpR66/src/main/java/org/waarp/openr66/database/data/DbTaskRunner.java
+++ b/WaarpR66/src/main/java/org/waarp/openr66/database/data/DbTaskRunner.java
@@ -369,12 +369,12 @@ public class DbTaskRunner extends AbstractDbDataDao<Transfer> {
     if (startTime != null) {
       pojo = new Transfer(requested, rule.getIdRule(), requestPacket.getMode(),
                           isSender, requestPacket.getFilename(),
-                          requestPacket.getFileInformation(),
+                          requestPacket.getTransferInformation(),
                           requestPacket.getBlocksize(), startTime);
     } else {
       pojo = new Transfer(requested, rule.getIdRule(), requestPacket.getMode(),
                           isSender, requestPacket.getFilename(),
-                          requestPacket.getFileInformation(),
+                          requestPacket.getTransferInformation(),
                           requestPacket.getBlocksize());
     }
 
@@ -423,7 +423,7 @@ public class DbTaskRunner extends AbstractDbDataDao<Transfer> {
     pojo = new Transfer(getRequested(session, requestPacket), rule.getIdRule(),
                         requestPacket.getMode(), isSender,
                         requestPacket.getFilename(),
-                        requestPacket.getFileInformation(),
+                        requestPacket.getTransferInformation(),
                         requestPacket.getBlocksize());
     pojo.setRequester(getRequester(session, requestPacket));
     pojo.setRank(requestPacket.getRank());
@@ -2350,11 +2350,20 @@ public class DbTaskRunner extends AbstractDbDataDao<Transfer> {
   }
 
   /**
-   * @param map the Map to set as Json string to transferInformation
+   * @param map the Map to add as Json string to transferInformation
    */
   public void setTransferMap(Map<String, Object> map) {
     pojo.setTransferInfo(
-        JsonHandler.writeAsString(map) + " " + getOtherInfoOutOfMap().trim());
+        getOtherInfoOutOfMap().trim() + " " + JsonHandler.writeAsString(map));
+  }
+
+  /**
+   * @param transferInfo the transfer Information to set
+   */
+  public void setTransferInfo(String transferInfo) {
+    pojo.setTransferInfo(getOutOfMapFromString(transferInfo).trim() + " " +
+                         JsonHandler
+                             .writeAsString(getMapFromString(transferInfo)));
   }
 
   /**
@@ -3577,8 +3586,8 @@ public class DbTaskRunner extends AbstractDbDataDao<Transfer> {
     }
     return new RequestPacket(pojo.getRule(), pojo.getTransferMode(),
                              pojo.getOriginalName(), pojo.getBlockSize(),
-                             pojo.getRank(), pojo.getId(), pojo.getFileInfo(),
-                             originalSize, sep);
+                             pojo.getRank(), pojo.getId(),
+                             pojo.getTransferInfo(), originalSize, sep);
   }
 
   /**

--- a/WaarpR66/src/main/java/org/waarp/openr66/protocol/http/restv2/RestConstants.java
+++ b/WaarpR66/src/main/java/org/waarp/openr66/protocol/http/restv2/RestConstants.java
@@ -429,6 +429,7 @@ public final class RestConstants {
     public static final String FILENAME = "filename";
     public static final String START_TRANS = "startTrans";
     public static final String STOP_TRANS = "stopTrans";
+    public static final String FOLLOW_ID = "followId";
 
     private GetTransfersParams() {
     }

--- a/WaarpR66/src/main/java/org/waarp/openr66/protocol/http/restv2/converters/TransferConverter.java
+++ b/WaarpR66/src/main/java/org/waarp/openr66/protocol/http/restv2/converters/TransferConverter.java
@@ -174,7 +174,7 @@ public final class TransferConverter {
     defaultTransfer.setRequester(serverName());
     defaultTransfer.setOwnerRequest(serverName());
     defaultTransfer.setBlockSize(Configuration.configuration.getBlockSize());
-    defaultTransfer.setTransferInfo("");
+    defaultTransfer.setTransferInfo("{}");
     defaultTransfer.setStart(new Timestamp(DateTime.now().getMillis()));
     final Transfer transfer = parseNode(object, defaultTransfer);
 

--- a/WaarpR66/src/main/java/org/waarp/openr66/protocol/http/restv2/converters/TransferConverter.java
+++ b/WaarpR66/src/main/java/org/waarp/openr66/protocol/http/restv2/converters/TransferConverter.java
@@ -360,6 +360,12 @@ public final class TransferConverter {
         } else {
           errors.add(ILLEGAL_FIELD_VALUE(name, value.toString()));
         }
+      } else if (name.equalsIgnoreCase(TRANSFER_INFO)) {
+        if (value.isTextual()) {
+          transfer.setTransferInfo(value.asText());
+        } else {
+          errors.add(ILLEGAL_FIELD_VALUE(name, value.toString()));
+        }
       } else if (name.equalsIgnoreCase(START)) {
         if (value.isTextual()) {
           try {

--- a/WaarpR66/src/main/java/org/waarp/openr66/protocol/http/restv2/dbhandlers/TransfersHandler.java
+++ b/WaarpR66/src/main/java/org/waarp/openr66/protocol/http/restv2/dbhandlers/TransfersHandler.java
@@ -34,6 +34,7 @@ import org.waarp.openr66.dao.DAOFactory;
 import org.waarp.openr66.dao.Filter;
 import org.waarp.openr66.dao.TransferDAO;
 import org.waarp.openr66.dao.exception.DAOConnectionException;
+import org.waarp.openr66.database.data.DbTaskRunner;
 import org.waarp.openr66.pojo.Transfer;
 import org.waarp.openr66.protocol.http.restv2.converters.TransferConverter;
 import org.waarp.openr66.protocol.http.restv2.errors.RestError;
@@ -114,6 +115,8 @@ public class TransfersHandler extends AbstractRestDbHandler {
    * @param filename filter transfers of a particular file
    * @param startTrans lower bound for the transfers' starting date
    * @param stopTrans upper bound for the transfers' starting date
+   * @param followId the followId to find, should be the only one, except
+   *     LIMIT, OFFSET, ORDER
    */
   @GET
   @Consumes(APPLICATION_FORM_URLENCODED)
@@ -136,7 +139,9 @@ public class TransfersHandler extends AbstractRestDbHandler {
                              @QueryParam(START_TRANS) @DefaultValue("")
                                  String startTrans,
                              @QueryParam(STOP_TRANS) @DefaultValue("")
-                                 String stopTrans) {
+                                 String stopTrans,
+                             @QueryParam(FOLLOW_ID) @DefaultValue("")
+                                 String followId) {
 
     final ArrayList<RestError> errors = new ArrayList<RestError>();
 
@@ -193,6 +198,9 @@ public class TransfersHandler extends AbstractRestDbHandler {
       } catch (final IllegalArgumentException e) {
         errors.add(ILLEGAL_PARAMETER_VALUE(STATUS, statusStr));
       }
+    }
+    if (!followId.isEmpty()) {
+      filters.add(DbTaskRunner.getFollowIdFilter(followId));
     }
 
     if (!errors.isEmpty()) {

--- a/WaarpR66/src/main/java/org/waarp/openr66/protocol/localhandler/TransferActions.java
+++ b/WaarpR66/src/main/java/org/waarp/openr66/protocol/localhandler/TransferActions.java
@@ -300,7 +300,7 @@ public class TransferActions extends ServerActions {
         packet = new RequestPacket(packet.getRulename(), packet.getMode(),
                                    packet.getFilename(), blocksize,
                                    packet.getRank(), packet.getSpecialId(),
-                                   packet.getFileInformation(),
+                                   packet.getTransferInformation(),
                                    packet.getOriginalSize(), sep);
       }
     }
@@ -372,7 +372,7 @@ public class TransferActions extends ServerActions {
         "Filesize: " + packet.getOriginalSize() + ':' + runner.isSender());
     if (!shouldInformBack) {
       shouldInformBack =
-          !packet.getFileInformation().equals(runner.getFileInformation());
+          !packet.getTransferInformation().equals(runner.getFileInformation());
     }
     if (runner.isFileMoved() && runner.isSender() && runner.isInTransfer() &&
         runner.getRank() == 0 && !packet.isToValidate()) {
@@ -731,7 +731,7 @@ public class TransferActions extends ServerActions {
       request.setFilesize(packet.getOriginalSize());
       final String infoTransfer = runner.getFileInformation();
       if (infoTransfer != null &&
-          !infoTransfer.equals(packet.getFileInformation())) {
+          !infoTransfer.equals(packet.getTransferInformation())) {
         request.setFileInfo(runner.getFileInformation());
       }
       final JsonCommandPacket validPacket =
@@ -742,13 +742,13 @@ public class TransferActions extends ServerActions {
       final String infoTransfer = runner.getFileInformation();
       ValidPacket validPacket;
       if (infoTransfer != null &&
-          !infoTransfer.equals(packet.getFileInformation()) &&
+          !infoTransfer.equals(packet.getTransferInformation()) &&
           localChannelReference.getPartner().changeFileInfoEnabled()) {
         validPacket = new ValidPacket(info, runner.getFilename() +
                                             PartnerConfiguration.BAR_SEPARATOR_FIELD +
                                             packet.getOriginalSize() +
                                             PartnerConfiguration.BAR_SEPARATOR_FIELD +
-                                            packet.getFileInformation(),
+                                            packet.getTransferInformation(),
                                       LocalPacketFactory.REQUESTPACKET);
       } else {
         validPacket = new ValidPacket(info, runner.getFilename() +

--- a/WaarpR66/src/main/java/org/waarp/openr66/protocol/localhandler/packet/RequestPacket.java
+++ b/WaarpR66/src/main/java/org/waarp/openr66/protocol/localhandler/packet/RequestPacket.java
@@ -85,7 +85,7 @@ public class RequestPacket extends AbstractLocalPacket {
 
   protected long limit;
 
-  protected final String fileInformation;
+  protected final String transferInformation;
 
   protected String separator = PartnerConfiguration.getSEPARATOR_FIELD();
 
@@ -294,14 +294,14 @@ public class RequestPacket extends AbstractLocalPacket {
    * @param rank
    * @param specialId
    * @param valid
-   * @param fileInformation
+   * @param transferInformation
    * @param code
    * @param originalSize
    */
   private RequestPacket(String rulename, int mode, String filename,
                         int blocksize, int rank, long specialId, byte valid,
-                        String fileInformation, char code, long originalSize,
-                        String separator) {
+                        String transferInformation, char code,
+                        long originalSize, String separator) {
     this.rulename = rulename;
     this.mode = mode;
     this.filename = filename;
@@ -313,7 +313,7 @@ public class RequestPacket extends AbstractLocalPacket {
     this.rank = rank;
     this.specialId = specialId;
     way = valid;
-    this.fileInformation = fileInformation;
+    this.transferInformation = transferInformation;
     this.code = code;
     this.originalSize = originalSize;
     this.separator = separator;
@@ -326,14 +326,14 @@ public class RequestPacket extends AbstractLocalPacket {
    * @param blocksize
    * @param rank
    * @param specialId
-   * @param fileInformation
+   * @param transferInformation
    */
   public RequestPacket(String rulename, int mode, String filename,
                        int blocksize, int rank, long specialId,
-                       String fileInformation, long originalSize,
+                       String transferInformation, long originalSize,
                        String separator) {
     this(rulename, mode, filename, blocksize, rank, specialId, REQVALIDATE,
-         fileInformation, ErrorCode.InitOk.code, originalSize, separator);
+         transferInformation, ErrorCode.InitOk.code, originalSize, separator);
   }
 
   /**
@@ -341,18 +341,18 @@ public class RequestPacket extends AbstractLocalPacket {
    */
   private RequestPacket(String rulename, int mode, String filename,
                         int blocksize, int rank, long specialId, byte valid,
-                        String fileInformation, char code, long originalSize,
-                        long limit, String separator) {
+                        String transferInformation, char code,
+                        long originalSize, long limit, String separator) {
     this(rulename, mode, filename, blocksize, rank, specialId, valid,
-         fileInformation, code, originalSize, separator);
+         transferInformation, code, originalSize, separator);
     this.limit = limit;
   }
 
   @Override
   public void createEnd(LocalChannelReference lcr)
       throws OpenR66ProtocolPacketException {
-    if (fileInformation != null) {
-      end = Unpooled.wrappedBuffer(fileInformation.getBytes());
+    if (transferInformation != null) {
+      end = Unpooled.wrappedBuffer(transferInformation.getBytes());
     }
   }
 
@@ -421,7 +421,7 @@ public class RequestPacket extends AbstractLocalPacket {
   @Override
   public String toString() {
     return "RequestPacket: " + specialId + " : " + rulename + " : " + mode +
-           " :  " + filename + " : " + fileInformation + " : " + blocksize +
+           " :  " + filename + " : " + transferInformation + " : " + blocksize +
            " : " + rank + " : " + way + " : " + code + " : " + originalSize +
            " : " + limit;
   }
@@ -457,8 +457,8 @@ public class RequestPacket extends AbstractLocalPacket {
   /**
    * @return the fileInformation
    */
-  public String getFileInformation() {
-    return fileInformation;
+  public String getTransferInformation() {
+    return transferInformation;
   }
 
   /**

--- a/WaarpR66/src/test/java/org/waarp/openr66/client/TransferArgsTest.java
+++ b/WaarpR66/src/test/java/org/waarp/openr66/client/TransferArgsTest.java
@@ -171,15 +171,15 @@ public class TransferArgsTest extends TestAbstract {
     String[] argsComplete = {
         TransferArgs.TO_ARG, "hosta", TransferArgs.FILE_ARG, "testTaskBig.txt",
         TransferArgs.RULE_ARG, "rule3", TransferArgs.HASH_ARG,
-        TransferArgs.BLOCK_ARG, "1000", TransferArgs.INFO_ARG, "no_information",
-        "otherNotTaken"
+        TransferArgs.NO_FOLLOW_ARG, TransferArgs.BLOCK_ARG, "1000",
+        TransferArgs.INFO_ARG, "no_information", "otherNotTaken"
     };
     transferArgs = AbstractTransfer.getParamsInternal(0, argsComplete);
     assertNotNull(transferArgs);
     assertEquals("hosta", transferArgs.getRemoteHost());
     assertEquals("testTaskBig.txt", transferArgs.getFilename());
     assertEquals("rule3", transferArgs.getRulename());
-    assertEquals("no_information", transferArgs.getFileinfo());
+    assertEquals("no_information", transferArgs.getTransferInfo());
     assertEquals(true, transferArgs.isMD5());
     assertEquals(1000, transferArgs.getBlockSize());
     assertNull(transferArgs.getStartTime());
@@ -189,15 +189,16 @@ public class TransferArgsTest extends TestAbstract {
     String[] argsCompleteSeparator = {
         TransferArgs.TO_ARG, "hosta", TransferArgs.FILE_ARG, "testTaskBig.txt",
         TransferArgs.RULE_ARG, "rule3", TransferArgs.HASH_ARG,
-        TransferArgs.BLOCK_ARG, "1000", TransferArgs.INFO_ARG, "no_information",
-        TransferArgs.SEPARATOR_SEND, TransferArgs.DELAY_ARG, "abc"
+        TransferArgs.NO_FOLLOW_ARG, TransferArgs.BLOCK_ARG, "1000",
+        TransferArgs.INFO_ARG, "no_information", TransferArgs.SEPARATOR_SEND,
+        TransferArgs.DELAY_ARG, "abc"
     };
     transferArgs = AbstractTransfer.getParamsInternal(0, argsCompleteSeparator);
     assertNotNull(transferArgs);
     assertEquals("hosta", transferArgs.getRemoteHost());
     assertEquals("testTaskBig.txt", transferArgs.getFilename());
     assertEquals("rule3", transferArgs.getRulename());
-    assertEquals("no_information", transferArgs.getFileinfo());
+    assertEquals("no_information", transferArgs.getTransferInfo());
     assertEquals(true, transferArgs.isMD5());
     assertEquals(1000, transferArgs.getBlockSize());
     assertNull(transferArgs.getStartTime());
@@ -207,14 +208,15 @@ public class TransferArgsTest extends TestAbstract {
         TransferArgs.SEPARATOR_SEND, TransferArgs.DELAY_ARG, "abc",
         TransferArgs.TO_ARG, "hosta", TransferArgs.FILE_ARG, "testTaskBig.txt",
         TransferArgs.RULE_ARG, "rule3", TransferArgs.HASH_ARG,
-        TransferArgs.BLOCK_ARG, "1000", TransferArgs.INFO_ARG, "no_information"
+        TransferArgs.NO_FOLLOW_ARG, TransferArgs.BLOCK_ARG, "1000",
+        TransferArgs.INFO_ARG, "no_information"
     };
     transferArgs = AbstractTransfer.getParamsInternal(3, argsCompleteRankNot0);
     assertNotNull(transferArgs);
     assertEquals("hosta", transferArgs.getRemoteHost());
     assertEquals("testTaskBig.txt", transferArgs.getFilename());
     assertEquals("rule3", transferArgs.getRulename());
-    assertEquals("no_information", transferArgs.getFileinfo());
+    assertEquals("no_information", transferArgs.getTransferInfo());
     assertEquals(true, transferArgs.isMD5());
     assertEquals(1000, transferArgs.getBlockSize());
     assertNull(transferArgs.getStartTime());
@@ -231,7 +233,7 @@ public class TransferArgsTest extends TestAbstract {
     assertEquals("hosta", transferArgs.getRemoteHost());
     assertEquals("testTaskBig.txt", transferArgs.getFilename());
     assertEquals("rule3", transferArgs.getRulename());
-    assertEquals("no_information", transferArgs.getFileinfo());
+    assertTrue(transferArgs.getTransferInfo().startsWith("no_information {"));
     assertEquals(true, transferArgs.isMD5());
     assertEquals(1000, transferArgs.getBlockSize());
     assertNull(transferArgs.getStartTime());
@@ -249,7 +251,7 @@ public class TransferArgsTest extends TestAbstract {
     assertEquals("hosta", transferArgs.getRemoteHost());
     assertEquals("testTaskBig.txt", transferArgs.getFilename());
     assertEquals("rule3", transferArgs.getRulename());
-    assertEquals("no_information", transferArgs.getFileinfo());
+    assertTrue(transferArgs.getTransferInfo().startsWith("no_information {"));
     assertEquals(true, transferArgs.isMD5());
     assertEquals(1000, transferArgs.getBlockSize());
     assertNull(transferArgs.getStartTime());
@@ -269,7 +271,7 @@ public class TransferArgsTest extends TestAbstract {
     assertEquals("hosta", transferArgs.getRemoteHost());
     assertEquals("testTaskBig.txt", transferArgs.getFilename());
     assertEquals("rule3", transferArgs.getRulename());
-    assertEquals("no_information", transferArgs.getFileinfo());
+    assertTrue(transferArgs.getTransferInfo().startsWith("no_information {"));
     assertEquals(true, transferArgs.isMD5());
     assertEquals(1000, transferArgs.getBlockSize());
     Date date;
@@ -289,15 +291,15 @@ public class TransferArgsTest extends TestAbstract {
         TransferArgs.TO_ARG, "hosta", TransferArgs.FILE_ARG, "testTaskBig.txt",
         TransferArgs.RULE_ARG, "rule3", TransferArgs.HASH_ARG,
         TransferArgs.NOTLOGWARN_ARG, TransferArgs.BLOCK_ARG, "1000",
-        TransferArgs.DELAY_ARG, "+100", TransferArgs.INFO_ARG, "no_information",
-        "otherNotTaken"
+        TransferArgs.NO_FOLLOW_ARG, TransferArgs.DELAY_ARG, "+100",
+        TransferArgs.INFO_ARG, "no_information", "otherNotTaken"
     };
     transferArgs = AbstractTransfer.getParamsInternal(0, argsCompleteWithDelay);
     assertNotNull(transferArgs);
     assertEquals("hosta", transferArgs.getRemoteHost());
     assertEquals("testTaskBig.txt", transferArgs.getFilename());
     assertEquals("rule3", transferArgs.getRulename());
-    assertEquals("no_information", transferArgs.getFileinfo());
+    assertEquals("no_information", transferArgs.getTransferInfo());
     assertEquals(true, transferArgs.isMD5());
     assertEquals(1000, transferArgs.getBlockSize());
     assertTrue(transferArgs.getStartTime().before(
@@ -320,20 +322,20 @@ public class TransferArgsTest extends TestAbstract {
     assertEquals("hosta", transferArgs.getRemoteHost());
     assertEquals("testTaskBig.txt", transferArgs.getFilename());
     assertEquals("rule3", transferArgs.getRulename());
-    assertEquals("no_information", transferArgs.getFileinfo());
+    assertTrue(transferArgs.getTransferInfo().startsWith("no_information {"));
     assertEquals(true, transferArgs.isMD5());
     assertEquals(1000, transferArgs.getBlockSize());
     assertTrue(transferArgs.isNolog());
     assertTrue(transferArgs.isNormalInfoAsWarn());
     assertEquals(ILLEGALVALUE, transferArgs.getId());
-    assertNull(transferArgs.getFollowId());
+    assertNotNull(transferArgs.getFollowId());
 
     // Check complete example
     String[] argsCompleteWithFollow = {
         TransferArgs.TO_ARG, "hosta", TransferArgs.FILE_ARG, "testTaskBig.txt",
         TransferArgs.RULE_ARG, "rule3", TransferArgs.HASH_ARG,
-        TransferArgs.BLOCK_ARG, "1000", TransferArgs.FOLLOW_ARG,
-        TransferArgs.INFO_ARG, "no_information", "otherNotTaken"
+        TransferArgs.BLOCK_ARG, "1000", TransferArgs.INFO_ARG, "no_information",
+        "otherNotTaken"
     };
     transferArgs =
         AbstractTransfer.getParamsInternal(0, argsCompleteWithFollow);
@@ -341,9 +343,9 @@ public class TransferArgsTest extends TestAbstract {
     assertEquals("hosta", transferArgs.getRemoteHost());
     assertEquals("testTaskBig.txt", transferArgs.getFilename());
     assertEquals("rule3", transferArgs.getRulename());
-    logger.warn(transferArgs.getFileinfo());
-    assertTrue(transferArgs.getFileinfo().endsWith("no_information"));
-    assertTrue(transferArgs.getFileinfo().contains(FOLLOW_JSON_KEY));
+    logger.warn(transferArgs.getTransferInfo());
+    assertTrue(transferArgs.getTransferInfo().startsWith("no_information {"));
+    assertTrue(transferArgs.getTransferInfo().contains(FOLLOW_JSON_KEY));
     assertEquals(true, transferArgs.isMD5());
     assertEquals(1000, transferArgs.getBlockSize());
     assertFalse(transferArgs.isNolog());
@@ -355,8 +357,8 @@ public class TransferArgsTest extends TestAbstract {
     String[] argsCompleteWithFollowIncluded = {
         TransferArgs.TO_ARG, "hosta", TransferArgs.FILE_ARG, "testTaskBig.txt",
         TransferArgs.RULE_ARG, "rule3", TransferArgs.HASH_ARG,
-        TransferArgs.BLOCK_ARG, "1000", TransferArgs.FOLLOW_ARG,
-        TransferArgs.INFO_ARG, "no_information", FOLLOWARGJSON, "1234}"
+        TransferArgs.BLOCK_ARG, "1000", TransferArgs.INFO_ARG, "no_information",
+        FOLLOWARGJSON, "1234}"
     };
     transferArgs = TransferArgs
         .getParamsInternal(0, argsCompleteWithFollowIncluded, false);
@@ -364,7 +366,7 @@ public class TransferArgsTest extends TestAbstract {
     assertEquals("hosta", transferArgs.getRemoteHost());
     assertEquals("testTaskBig.txt", transferArgs.getFilename());
     assertEquals("rule3", transferArgs.getRulename());
-    assertEquals("no_information", transferArgs.getFileinfo());
+    assertEquals("no_information", transferArgs.getTransferInfo());
     assertEquals(true, transferArgs.isMD5());
     assertEquals(1000, transferArgs.getBlockSize());
     assertFalse(transferArgs.isNolog());
@@ -374,17 +376,16 @@ public class TransferArgsTest extends TestAbstract {
     assertNotEquals("1234", transferArgs.getFollowId());
     TransferArgs
         .getAllInfo(transferArgs, 0, argsCompleteWithFollowIncluded, null);
-    logger.warn(transferArgs.getFileinfo());
+    logger.warn(transferArgs.getTransferInfo());
     assertEquals("1234", transferArgs.getFollowId());
-    assertTrue(transferArgs.getFileinfo().endsWith("no_information"));
-    assertTrue(transferArgs.getFileinfo().contains(FOLLOW_JSON_KEY));
+    assertTrue(transferArgs.getTransferInfo().startsWith("no_information {"));
+    assertTrue(transferArgs.getTransferInfo().contains(FOLLOW_JSON_KEY));
 
     String[] argsCompleteWithFollowIncludedAndMore = {
         TransferArgs.TO_ARG, "hosta", TransferArgs.FILE_ARG, "testTaskBig.txt",
         TransferArgs.RULE_ARG, "rule3", TransferArgs.HASH_ARG,
-        TransferArgs.BLOCK_ARG, "1000", TransferArgs.FOLLOW_ARG,
-        TransferArgs.INFO_ARG, "no_information", FOLLOWARGJSON,
-        "1234} {'key': 'value'} test after"
+        TransferArgs.BLOCK_ARG, "1000", TransferArgs.INFO_ARG, "no_information",
+        FOLLOWARGJSON, "1234} {'key': 'value'} test after"
     };
     transferArgs = TransferArgs
         .getParamsInternal(0, argsCompleteWithFollowIncludedAndMore, false);
@@ -392,7 +393,7 @@ public class TransferArgsTest extends TestAbstract {
     assertEquals("hosta", transferArgs.getRemoteHost());
     assertEquals("testTaskBig.txt", transferArgs.getFilename());
     assertEquals("rule3", transferArgs.getRulename());
-    assertEquals("no_information", transferArgs.getFileinfo());
+    assertEquals("no_information", transferArgs.getTransferInfo());
     assertEquals(true, transferArgs.isMD5());
     assertEquals(1000, transferArgs.getBlockSize());
     assertFalse(transferArgs.isNolog());
@@ -403,21 +404,21 @@ public class TransferArgsTest extends TestAbstract {
     TransferArgs
         .getAllInfo(transferArgs, 0, argsCompleteWithFollowIncludedAndMore,
                     null);
-    logger.warn(transferArgs.getFileinfo());
+    logger.warn(transferArgs.getTransferInfo());
     assertEquals("1234", transferArgs.getFollowId());
-    assertTrue(
-        transferArgs.getFileinfo().endsWith("no_information   test after"));
-    assertTrue(transferArgs.getFileinfo().contains(FOLLOW_JSON_KEY));
-    assertTrue(DbTaskRunner.getMapFromString(transferArgs.getFileinfo())
+    assertTrue(transferArgs.getTransferInfo()
+                           .startsWith("no_information   test after {"));
+    assertTrue(transferArgs.getTransferInfo().contains(FOLLOW_JSON_KEY));
+    assertTrue(DbTaskRunner.getMapFromString(transferArgs.getTransferInfo())
                            .containsKey("key"));
-    assertTrue(DbTaskRunner.getMapFromString(transferArgs.getFileinfo())
+    assertTrue(DbTaskRunner.getMapFromString(transferArgs.getTransferInfo())
                            .containsKey(FOLLOW_JSON_KEY));
 
     String[] argsCompleteWithFollowCopied = {
         TransferArgs.TO_ARG, "hosta", TransferArgs.FILE_ARG, "testTaskBig.txt",
         TransferArgs.RULE_ARG, "rule3", TransferArgs.HASH_ARG,
-        TransferArgs.BLOCK_ARG, "1000", TransferArgs.FOLLOW_ARG,
-        TransferArgs.INFO_ARG, "no_information", "extra-info"
+        TransferArgs.BLOCK_ARG, "1000", TransferArgs.INFO_ARG, "no_information",
+        "extra-info"
     };
     transferArgs =
         TransferArgs.getParamsInternal(0, argsCompleteWithFollowCopied, false);
@@ -425,7 +426,7 @@ public class TransferArgsTest extends TestAbstract {
     assertEquals("hosta", transferArgs.getRemoteHost());
     assertEquals("testTaskBig.txt", transferArgs.getFilename());
     assertEquals("rule3", transferArgs.getRulename());
-    assertEquals("no_information", transferArgs.getFileinfo());
+    assertEquals("no_information", transferArgs.getTransferInfo());
     assertEquals(true, transferArgs.isMD5());
     assertEquals(1000, transferArgs.getBlockSize());
     assertFalse(transferArgs.isNolog());
@@ -435,10 +436,10 @@ public class TransferArgsTest extends TestAbstract {
     assertNotEquals("1234", transferArgs.getFollowId());
     TransferArgs.getAllInfo(transferArgs, 0, argsCompleteWithFollowCopied,
                             FOLLOWARGJSON + " 1234}");
-    logger.warn(transferArgs.getFileinfo());
+    logger.warn(transferArgs.getTransferInfo());
     assertEquals("1234", transferArgs.getFollowId());
     assertTrue(
-        transferArgs.getFileinfo().endsWith("no_information extra-info"));
-    assertTrue(transferArgs.getFileinfo().contains(FOLLOW_JSON_KEY));
+        transferArgs.getTransferInfo().startsWith("no_information extra-info"));
+    assertTrue(transferArgs.getTransferInfo().contains(FOLLOW_JSON_KEY));
   }
 } 

--- a/WaarpR66/src/test/java/org/waarp/openr66/client/TransferArgsTest.java
+++ b/WaarpR66/src/test/java/org/waarp/openr66/client/TransferArgsTest.java
@@ -1,0 +1,403 @@
+/*
+ * This file is part of Waarp Project (named also Waarp or GG).
+ *
+ *  Copyright (c) 2019, Waarp SAS, and individual contributors by the @author
+ *  tags. See the COPYRIGHT.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ *  All Waarp Project is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * Waarp is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ * Waarp . If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.waarp.openr66.client;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.waarp.common.digest.FilesystemBasedDigest;
+import org.waarp.common.logging.SysErrLogger;
+import org.waarp.openr66.context.R66FiniteDualStates;
+import org.waarp.openr66.database.data.DbHostAuth;
+import org.waarp.openr66.protocol.configuration.Configuration;
+import org.waarp.openr66.protocol.junit.NetworkClientTest;
+import org.waarp.openr66.protocol.junit.TestAbstract;
+import org.waarp.openr66.protocol.localhandler.packet.AbstractLocalPacket;
+import org.waarp.openr66.protocol.localhandler.packet.JsonCommandPacket;
+import org.waarp.openr66.protocol.localhandler.packet.LocalPacketFactory;
+import org.waarp.openr66.protocol.localhandler.packet.json.ShutdownOrBlockJsonPacket;
+import org.waarp.openr66.protocol.utils.R66Future;
+
+import java.io.File;
+import java.net.SocketAddress;
+import java.sql.Timestamp;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import static org.junit.Assert.*;
+import static org.waarp.common.database.DbConstant.*;
+
+/**
+ * AbstractTransfer Tester.
+ */
+public class TransferArgsTest extends TestAbstract {
+  private static final String CONFIG_SERVER_A_MINIMAL_XML =
+      "config-serverA-minimal.xml";
+  private static final String LINUX_CONFIG_CONFIG_SERVER_INIT_A_XML =
+      "Linux/config/config-serverInitA.xml";
+  private static final String CONFIG_CLIENT_A_XML = "config-clientA.xml";
+
+  /**
+   * @throws Exception
+   */
+  @BeforeClass
+  public static void setUpBeforeClass() throws Exception {
+    final ClassLoader classLoader = NetworkClientTest.class.getClassLoader();
+    final File file =
+        new File(classLoader.getResource("logback-test.xml").getFile());
+    setUpBeforeClassMinimal(LINUX_CONFIG_CONFIG_SERVER_INIT_A_XML);
+    setUpDbBeforeClass();
+    setUpBeforeClassServer(LINUX_CONFIG_CONFIG_SERVER_INIT_A_XML,
+                           CONFIG_SERVER_A_MINIMAL_XML, true);
+    setUpBeforeClassClient(CONFIG_CLIENT_A_XML);
+    final File totestBig = generateOutFile("/tmp/R66/out/testTaskBig.txt", 100);
+  }
+
+  /**
+   * @throws Exception
+   */
+  @AfterClass
+  public static void tearDownAfterClass() throws Exception {
+    Thread.sleep(100);
+    final DbHostAuth host = new DbHostAuth("hostas");
+    final SocketAddress socketServerAddress;
+    try {
+      socketServerAddress = host.getSocketAddress();
+    } catch (final IllegalArgumentException e) {
+      logger.error("Needs a correct configuration file as first argument");
+      return;
+    }
+    final byte scode = -1;
+
+    // Shutdown server
+    logger.warn("Shutdown Server");
+    Configuration.configuration.setTimeoutCon(100);
+    final R66Future future = new R66Future(true);
+    final ShutdownOrBlockJsonPacket node8 = new ShutdownOrBlockJsonPacket();
+    node8.setRestartOrBlock(false);
+    node8.setShutdownOrBlock(true);
+    node8.setKey(FilesystemBasedDigest.passwdCrypt(
+        Configuration.configuration.getServerAdminKey()));
+    final AbstractLocalPacket valid =
+        new JsonCommandPacket(node8, LocalPacketFactory.BLOCKREQUESTPACKET);
+    sendInformation(valid, socketServerAddress, future, scode, false,
+                    R66FiniteDualStates.SHUTDOWN, true);
+    Thread.sleep(200);
+
+    tearDownAfterClassClient();
+    tearDownAfterClassMinimal();
+    tearDownAfterClassServer();
+  }
+
+  /**
+   * Method: getParamsInternal(int rank, String[] args)
+   */
+  @Test
+  public void testGetParamsInternal() throws Exception {
+    // Wrong arguments
+    TransferArgs transferArgs = AbstractTransfer.getParamsInternal(0, null);
+    assertNull(transferArgs);
+    transferArgs = AbstractTransfer.getParamsInternal(0, new String[0]);
+    assertNull(transferArgs);
+    String[] argsIncomplete = {
+        TransferArgs.TO_ARG, "hosta", TransferArgs.FILE_ARG
+    };
+    transferArgs = AbstractTransfer.getParamsInternal(0, argsIncomplete);
+    assertNull(transferArgs);
+    String[] argsIncomplete2 = {
+        TransferArgs.TO_ARG, "hosta"
+    };
+    transferArgs = AbstractTransfer.getParamsInternal(0, argsIncomplete2);
+    assertNull(transferArgs);
+    String[] argsWrongBlock = {
+        TransferArgs.TO_ARG, "hosta", TransferArgs.FILE_ARG, "testTaskBig.txt",
+        TransferArgs.RULE_ARG, "rule3", TransferArgs.BLOCK_ARG, "123abc"
+    };
+    transferArgs = AbstractTransfer.getParamsInternal(0, argsWrongBlock);
+    assertNull(transferArgs);
+    String[] argsWrongDelay = {
+        TransferArgs.TO_ARG, "hosta", TransferArgs.FILE_ARG, "testTaskBig.txt",
+        TransferArgs.RULE_ARG, "rule3", TransferArgs.DELAY_ARG, "123abc"
+    };
+    transferArgs = AbstractTransfer.getParamsInternal(0, argsWrongDelay);
+    assertNull(transferArgs);
+    String[] argsWrongDelayPlus = {
+        TransferArgs.TO_ARG, "hosta", TransferArgs.FILE_ARG, "testTaskBig.txt",
+        TransferArgs.RULE_ARG, "rule3", TransferArgs.DELAY_ARG, "+123abc"
+    };
+    transferArgs = AbstractTransfer.getParamsInternal(0, argsWrongDelayPlus);
+    assertNull(transferArgs);
+    String[] argsWrongStart = {
+        TransferArgs.TO_ARG, "hosta", TransferArgs.FILE_ARG, "testTaskBig.txt",
+        TransferArgs.RULE_ARG, "rule3", TransferArgs.START_ARG, "123abc"
+    };
+    transferArgs = AbstractTransfer.getParamsInternal(0, argsWrongStart);
+    assertNull(transferArgs);
+    String[] argsWrongId = {
+        TransferArgs.TO_ARG, "hosta", TransferArgs.FILE_ARG, "testTaskBig.txt",
+        TransferArgs.RULE_ARG, "rule3", TransferArgs.ID_ARG, "123abc"
+    };
+    transferArgs = AbstractTransfer.getParamsInternal(0, argsWrongId);
+    assertNull(transferArgs);
+    String[] argsNotExistId = {
+        TransferArgs.TO_ARG, "hosta", TransferArgs.ID_ARG, "123456"
+    };
+    transferArgs = AbstractTransfer.getParamsInternal(0, argsNotExistId);
+    assertNull(transferArgs);
+
+    // Check complete example
+    String[] argsComplete = {
+        TransferArgs.TO_ARG, "hosta", TransferArgs.FILE_ARG, "testTaskBig.txt",
+        TransferArgs.RULE_ARG, "rule3", TransferArgs.HASH_ARG,
+        TransferArgs.BLOCK_ARG, "1000", TransferArgs.INFO_ARG, "no_information",
+        "otherNotTaken"
+    };
+    transferArgs = AbstractTransfer.getParamsInternal(0, argsComplete);
+    assertNotNull(transferArgs);
+    assertEquals("hosta", transferArgs.remoteHost);
+    assertEquals("testTaskBig.txt", transferArgs.filename);
+    assertEquals("rule3", transferArgs.rulename);
+    assertEquals("no_information", transferArgs.fileinfo);
+    assertEquals(true, transferArgs.isMD5);
+    assertEquals(1000, transferArgs.blocksize);
+    assertNull(transferArgs.startTime);
+    assertEquals(ILLEGALVALUE, transferArgs.id);
+
+    // Check complete example
+    String[] argsCompleteSeparator = {
+        TransferArgs.TO_ARG, "hosta", TransferArgs.FILE_ARG, "testTaskBig.txt",
+        TransferArgs.RULE_ARG, "rule3", TransferArgs.HASH_ARG,
+        TransferArgs.BLOCK_ARG, "1000", TransferArgs.INFO_ARG, "no_information",
+        TransferArgs.SEPARATOR_SEND, TransferArgs.DELAY_ARG, "abc"
+    };
+    transferArgs = AbstractTransfer.getParamsInternal(0, argsCompleteSeparator);
+    assertNotNull(transferArgs);
+    assertEquals("hosta", transferArgs.remoteHost);
+    assertEquals("testTaskBig.txt", transferArgs.filename);
+    assertEquals("rule3", transferArgs.rulename);
+    assertEquals("no_information", transferArgs.fileinfo);
+    assertEquals(true, transferArgs.isMD5);
+    assertEquals(1000, transferArgs.blocksize);
+    assertNull(transferArgs.startTime);
+    assertEquals(ILLEGALVALUE, transferArgs.id);
+
+    String[] argsCompleteRankNot0 = {
+        TransferArgs.SEPARATOR_SEND, TransferArgs.DELAY_ARG, "abc",
+        TransferArgs.TO_ARG, "hosta", TransferArgs.FILE_ARG, "testTaskBig.txt",
+        TransferArgs.RULE_ARG, "rule3", TransferArgs.HASH_ARG,
+        TransferArgs.BLOCK_ARG, "1000", TransferArgs.INFO_ARG, "no_information"
+    };
+    transferArgs = AbstractTransfer.getParamsInternal(3, argsCompleteRankNot0);
+    assertNotNull(transferArgs);
+    assertEquals("hosta", transferArgs.remoteHost);
+    assertEquals("testTaskBig.txt", transferArgs.filename);
+    assertEquals("rule3", transferArgs.rulename);
+    assertEquals("no_information", transferArgs.fileinfo);
+    assertEquals(true, transferArgs.isMD5);
+    assertEquals(1000, transferArgs.blocksize);
+    assertNull(transferArgs.startTime);
+    assertEquals(ILLEGALVALUE, transferArgs.id);
+
+    String[] argsCompleteAlias = {
+        TransferArgs.TO_ARG, "myhosta", TransferArgs.FILE_ARG,
+        "testTaskBig.txt", TransferArgs.RULE_ARG, "rule3",
+        TransferArgs.HASH_ARG, TransferArgs.BLOCK_ARG, "1000",
+        TransferArgs.INFO_ARG, "no_information", "otherNotTaken"
+    };
+    transferArgs = AbstractTransfer.getParamsInternal(0, argsCompleteAlias);
+    assertNotNull(transferArgs);
+    assertEquals("hosta", transferArgs.remoteHost);
+    assertEquals("testTaskBig.txt", transferArgs.filename);
+    assertEquals("rule3", transferArgs.rulename);
+    assertEquals("no_information", transferArgs.fileinfo);
+    assertEquals(true, transferArgs.isMD5);
+    assertEquals(1000, transferArgs.blocksize);
+    assertNull(transferArgs.startTime);
+    assertEquals(ILLEGALVALUE, transferArgs.id);
+
+    // Check complete example
+    String[] argsCompleteWithId = {
+        TransferArgs.TO_ARG, "hosta", TransferArgs.FILE_ARG, "testTaskBig.txt",
+        TransferArgs.RULE_ARG, "rule3", TransferArgs.HASH_ARG,
+        TransferArgs.BLOCK_ARG, "1000", TransferArgs.ID_ARG, "1234",
+        TransferArgs.INFO_ARG, "no_information", "otherNotTaken"
+    };
+    transferArgs = AbstractTransfer.getParamsInternal(0, argsCompleteWithId);
+    assertNotNull(transferArgs);
+    assertEquals("hosta", transferArgs.remoteHost);
+    assertEquals("testTaskBig.txt", transferArgs.filename);
+    assertEquals("rule3", transferArgs.rulename);
+    assertEquals("no_information", transferArgs.fileinfo);
+    assertEquals(true, transferArgs.isMD5);
+    assertEquals(1000, transferArgs.blocksize);
+    assertNull(transferArgs.startTime);
+    assertEquals(1234, transferArgs.id);
+
+    // Check complete example
+    String[] argsCompleteWithTimeStart = {
+        TransferArgs.TO_ARG, "hosta", TransferArgs.FILE_ARG, "testTaskBig.txt",
+        TransferArgs.RULE_ARG, "rule3", TransferArgs.HASH_ARG,
+        TransferArgs.BLOCK_ARG, "1000", TransferArgs.START_ARG,
+        "20200601211201", TransferArgs.INFO_ARG, "no_information",
+        "otherNotTaken"
+    };
+    transferArgs =
+        AbstractTransfer.getParamsInternal(0, argsCompleteWithTimeStart);
+    assertNotNull(transferArgs);
+    assertEquals("hosta", transferArgs.remoteHost);
+    assertEquals("testTaskBig.txt", transferArgs.filename);
+    assertEquals("rule3", transferArgs.rulename);
+    assertEquals("no_information", transferArgs.fileinfo);
+    assertEquals(true, transferArgs.isMD5);
+    assertEquals(1000, transferArgs.blocksize);
+    Date date;
+    final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyyMMddHHmmss");
+    try {
+      date = dateFormat.parse("20200601211201");
+      assertTrue(transferArgs.startTime.equals(new Timestamp(date.getTime())));
+    } catch (final ParseException ignored) {
+      SysErrLogger.FAKE_LOGGER.ignoreLog(ignored);
+      fail(ignored.getMessage());
+    }
+    assertEquals(ILLEGALVALUE, transferArgs.id);
+
+    // Check complete example
+    String[] argsCompleteWithDelay = {
+        TransferArgs.TO_ARG, "hosta", TransferArgs.FILE_ARG, "testTaskBig.txt",
+        TransferArgs.RULE_ARG, "rule3", TransferArgs.HASH_ARG,
+        TransferArgs.NOTLOGWARN_ARG, TransferArgs.BLOCK_ARG, "1000",
+        TransferArgs.DELAY_ARG, "+100", TransferArgs.INFO_ARG, "no_information",
+        "otherNotTaken"
+    };
+    transferArgs = AbstractTransfer.getParamsInternal(0, argsCompleteWithDelay);
+    assertNotNull(transferArgs);
+    assertEquals("hosta", transferArgs.remoteHost);
+    assertEquals("testTaskBig.txt", transferArgs.filename);
+    assertEquals("rule3", transferArgs.rulename);
+    assertEquals("no_information", transferArgs.fileinfo);
+    assertEquals(true, transferArgs.isMD5);
+    assertEquals(1000, transferArgs.blocksize);
+    assertTrue(transferArgs.startTime
+                   .before(new Timestamp(System.currentTimeMillis() + 101)));
+    assertEquals(ILLEGALVALUE, transferArgs.id);
+    assertFalse(transferArgs.nolog);
+    assertFalse(transferArgs.normalInfoAsWarn);
+
+    // Check complete example
+    String[] argsCompleteWithNotLog = {
+        TransferArgs.TO_ARG, "hosta", TransferArgs.FILE_ARG, "testTaskBig.txt",
+        TransferArgs.RULE_ARG, "rule3", TransferArgs.HASH_ARG,
+        TransferArgs.BLOCK_ARG, "1000", TransferArgs.NOTLOG_ARG,
+        TransferArgs.LOGWARN_ARG, TransferArgs.INFO_ARG, "no_information",
+        "otherNotTaken"
+    };
+    transferArgs =
+        AbstractTransfer.getParamsInternal(0, argsCompleteWithNotLog);
+    assertNotNull(transferArgs);
+    assertEquals("hosta", transferArgs.remoteHost);
+    assertEquals("testTaskBig.txt", transferArgs.filename);
+    assertEquals("rule3", transferArgs.rulename);
+    assertEquals("no_information", transferArgs.fileinfo);
+    assertEquals(true, transferArgs.isMD5);
+    assertEquals(1000, transferArgs.blocksize);
+    assertTrue(transferArgs.nolog);
+    assertTrue(transferArgs.normalInfoAsWarn);
+    assertEquals(ILLEGALVALUE, transferArgs.id);
+    assertNull(transferArgs.follow);
+
+    // Check complete example
+    String[] argsCompleteWithFollow = {
+        TransferArgs.TO_ARG, "hosta", TransferArgs.FILE_ARG, "testTaskBig.txt",
+        TransferArgs.RULE_ARG, "rule3", TransferArgs.HASH_ARG,
+        TransferArgs.BLOCK_ARG, "1000", TransferArgs.FOLLOW_ARG,
+        TransferArgs.INFO_ARG, "no_information", "otherNotTaken"
+    };
+    transferArgs =
+        AbstractTransfer.getParamsInternal(0, argsCompleteWithFollow);
+    assertNotNull(transferArgs);
+    assertEquals("hosta", transferArgs.remoteHost);
+    assertEquals("testTaskBig.txt", transferArgs.filename);
+    assertEquals("rule3", transferArgs.rulename);
+    assertTrue(transferArgs.fileinfo
+                   .startsWith("no_information " + TransferArgs.FOLLOWARGJSON));
+    assertEquals(true, transferArgs.isMD5);
+    assertEquals(1000, transferArgs.blocksize);
+    assertFalse(transferArgs.nolog);
+    assertTrue(transferArgs.normalInfoAsWarn);
+    assertEquals(ILLEGALVALUE, transferArgs.id);
+    assertFalse(transferArgs.follow.isEmpty());
+
+    // Check complete example
+    String[] argsCompleteWithFollowIncluded = {
+        TransferArgs.TO_ARG, "hosta", TransferArgs.FILE_ARG, "testTaskBig.txt",
+        TransferArgs.RULE_ARG, "rule3", TransferArgs.HASH_ARG,
+        TransferArgs.BLOCK_ARG, "1000", TransferArgs.FOLLOW_ARG,
+        TransferArgs.INFO_ARG, "no_information", TransferArgs.FOLLOWARGJSON,
+        "1234}"
+    };
+    transferArgs = TransferArgs
+        .getParamsInternal(0, argsCompleteWithFollowIncluded, false);
+    assertNotNull(transferArgs);
+    assertEquals("hosta", transferArgs.remoteHost);
+    assertEquals("testTaskBig.txt", transferArgs.filename);
+    assertEquals("rule3", transferArgs.rulename);
+    assertEquals("no_information", transferArgs.fileinfo);
+    assertEquals(true, transferArgs.isMD5);
+    assertEquals(1000, transferArgs.blocksize);
+    assertFalse(transferArgs.nolog);
+    assertTrue(transferArgs.normalInfoAsWarn);
+    assertEquals(ILLEGALVALUE, transferArgs.id);
+    assertTrue(transferArgs.follow.isEmpty());
+    assertNotEquals("1234", transferArgs.follow);
+    TransferArgs
+        .getAllInfo(transferArgs, 0, argsCompleteWithFollowIncluded, null);
+    assertEquals("1234", transferArgs.follow);
+    assertEquals("no_information " + TransferArgs.FOLLOWARGJSON + " 1234}",
+                 transferArgs.fileinfo);
+
+    String[] argsCompleteWithFollowCopied = {
+        TransferArgs.TO_ARG, "hosta", TransferArgs.FILE_ARG, "testTaskBig.txt",
+        TransferArgs.RULE_ARG, "rule3", TransferArgs.HASH_ARG,
+        TransferArgs.BLOCK_ARG, "1000", TransferArgs.FOLLOW_ARG,
+        TransferArgs.INFO_ARG, "no_information", "extra-info"
+    };
+    transferArgs =
+        TransferArgs.getParamsInternal(0, argsCompleteWithFollowCopied, false);
+    assertNotNull(transferArgs);
+    assertEquals("hosta", transferArgs.remoteHost);
+    assertEquals("testTaskBig.txt", transferArgs.filename);
+    assertEquals("rule3", transferArgs.rulename);
+    assertEquals("no_information", transferArgs.fileinfo);
+    assertEquals(true, transferArgs.isMD5);
+    assertEquals(1000, transferArgs.blocksize);
+    assertFalse(transferArgs.nolog);
+    assertTrue(transferArgs.normalInfoAsWarn);
+    assertEquals(ILLEGALVALUE, transferArgs.id);
+    assertTrue(transferArgs.follow.isEmpty());
+    assertNotEquals("1234", transferArgs.follow);
+    TransferArgs.getAllInfo(transferArgs, 0, argsCompleteWithFollowCopied,
+                            TransferArgs.FOLLOWARGJSON + " 1234}");
+    assertEquals("1234", transferArgs.follow);
+    assertEquals(TransferArgs.FOLLOWARGJSON + " 1234} " + "no_information " +
+                 "extra-info", transferArgs.fileinfo);
+  }
+} 

--- a/WaarpR66/src/test/java/org/waarp/openr66/client/TransferArgsTest.java
+++ b/WaarpR66/src/test/java/org/waarp/openr66/client/TransferArgsTest.java
@@ -27,6 +27,7 @@ import org.waarp.common.digest.FilesystemBasedDigest;
 import org.waarp.common.logging.SysErrLogger;
 import org.waarp.openr66.context.R66FiniteDualStates;
 import org.waarp.openr66.database.data.DbHostAuth;
+import org.waarp.openr66.database.data.DbTaskRunner;
 import org.waarp.openr66.protocol.configuration.Configuration;
 import org.waarp.openr66.protocol.junit.NetworkClientTest;
 import org.waarp.openr66.protocol.junit.TestAbstract;
@@ -45,6 +46,7 @@ import java.util.Date;
 
 import static org.junit.Assert.*;
 import static org.waarp.common.database.DbConstant.*;
+import static org.waarp.openr66.client.TransferArgs.*;
 
 /**
  * AbstractTransfer Tester.
@@ -55,6 +57,7 @@ public class TransferArgsTest extends TestAbstract {
   private static final String LINUX_CONFIG_CONFIG_SERVER_INIT_A_XML =
       "Linux/config/config-serverInitA.xml";
   private static final String CONFIG_CLIENT_A_XML = "config-clientA.xml";
+  public static final String FOLLOWARGJSON = "{\"" + FOLLOW_JSON_KEY + "\":";
 
   /**
    * @throws Exception
@@ -173,14 +176,14 @@ public class TransferArgsTest extends TestAbstract {
     };
     transferArgs = AbstractTransfer.getParamsInternal(0, argsComplete);
     assertNotNull(transferArgs);
-    assertEquals("hosta", transferArgs.remoteHost);
-    assertEquals("testTaskBig.txt", transferArgs.filename);
-    assertEquals("rule3", transferArgs.rulename);
-    assertEquals("no_information", transferArgs.fileinfo);
-    assertEquals(true, transferArgs.isMD5);
-    assertEquals(1000, transferArgs.blocksize);
-    assertNull(transferArgs.startTime);
-    assertEquals(ILLEGALVALUE, transferArgs.id);
+    assertEquals("hosta", transferArgs.getRemoteHost());
+    assertEquals("testTaskBig.txt", transferArgs.getFilename());
+    assertEquals("rule3", transferArgs.getRulename());
+    assertEquals("no_information", transferArgs.getFileinfo());
+    assertEquals(true, transferArgs.isMD5());
+    assertEquals(1000, transferArgs.getBlockSize());
+    assertNull(transferArgs.getStartTime());
+    assertEquals(ILLEGALVALUE, transferArgs.getId());
 
     // Check complete example
     String[] argsCompleteSeparator = {
@@ -191,14 +194,14 @@ public class TransferArgsTest extends TestAbstract {
     };
     transferArgs = AbstractTransfer.getParamsInternal(0, argsCompleteSeparator);
     assertNotNull(transferArgs);
-    assertEquals("hosta", transferArgs.remoteHost);
-    assertEquals("testTaskBig.txt", transferArgs.filename);
-    assertEquals("rule3", transferArgs.rulename);
-    assertEquals("no_information", transferArgs.fileinfo);
-    assertEquals(true, transferArgs.isMD5);
-    assertEquals(1000, transferArgs.blocksize);
-    assertNull(transferArgs.startTime);
-    assertEquals(ILLEGALVALUE, transferArgs.id);
+    assertEquals("hosta", transferArgs.getRemoteHost());
+    assertEquals("testTaskBig.txt", transferArgs.getFilename());
+    assertEquals("rule3", transferArgs.getRulename());
+    assertEquals("no_information", transferArgs.getFileinfo());
+    assertEquals(true, transferArgs.isMD5());
+    assertEquals(1000, transferArgs.getBlockSize());
+    assertNull(transferArgs.getStartTime());
+    assertEquals(ILLEGALVALUE, transferArgs.getId());
 
     String[] argsCompleteRankNot0 = {
         TransferArgs.SEPARATOR_SEND, TransferArgs.DELAY_ARG, "abc",
@@ -208,14 +211,14 @@ public class TransferArgsTest extends TestAbstract {
     };
     transferArgs = AbstractTransfer.getParamsInternal(3, argsCompleteRankNot0);
     assertNotNull(transferArgs);
-    assertEquals("hosta", transferArgs.remoteHost);
-    assertEquals("testTaskBig.txt", transferArgs.filename);
-    assertEquals("rule3", transferArgs.rulename);
-    assertEquals("no_information", transferArgs.fileinfo);
-    assertEquals(true, transferArgs.isMD5);
-    assertEquals(1000, transferArgs.blocksize);
-    assertNull(transferArgs.startTime);
-    assertEquals(ILLEGALVALUE, transferArgs.id);
+    assertEquals("hosta", transferArgs.getRemoteHost());
+    assertEquals("testTaskBig.txt", transferArgs.getFilename());
+    assertEquals("rule3", transferArgs.getRulename());
+    assertEquals("no_information", transferArgs.getFileinfo());
+    assertEquals(true, transferArgs.isMD5());
+    assertEquals(1000, transferArgs.getBlockSize());
+    assertNull(transferArgs.getStartTime());
+    assertEquals(ILLEGALVALUE, transferArgs.getId());
 
     String[] argsCompleteAlias = {
         TransferArgs.TO_ARG, "myhosta", TransferArgs.FILE_ARG,
@@ -225,14 +228,14 @@ public class TransferArgsTest extends TestAbstract {
     };
     transferArgs = AbstractTransfer.getParamsInternal(0, argsCompleteAlias);
     assertNotNull(transferArgs);
-    assertEquals("hosta", transferArgs.remoteHost);
-    assertEquals("testTaskBig.txt", transferArgs.filename);
-    assertEquals("rule3", transferArgs.rulename);
-    assertEquals("no_information", transferArgs.fileinfo);
-    assertEquals(true, transferArgs.isMD5);
-    assertEquals(1000, transferArgs.blocksize);
-    assertNull(transferArgs.startTime);
-    assertEquals(ILLEGALVALUE, transferArgs.id);
+    assertEquals("hosta", transferArgs.getRemoteHost());
+    assertEquals("testTaskBig.txt", transferArgs.getFilename());
+    assertEquals("rule3", transferArgs.getRulename());
+    assertEquals("no_information", transferArgs.getFileinfo());
+    assertEquals(true, transferArgs.isMD5());
+    assertEquals(1000, transferArgs.getBlockSize());
+    assertNull(transferArgs.getStartTime());
+    assertEquals(ILLEGALVALUE, transferArgs.getId());
 
     // Check complete example
     String[] argsCompleteWithId = {
@@ -243,14 +246,14 @@ public class TransferArgsTest extends TestAbstract {
     };
     transferArgs = AbstractTransfer.getParamsInternal(0, argsCompleteWithId);
     assertNotNull(transferArgs);
-    assertEquals("hosta", transferArgs.remoteHost);
-    assertEquals("testTaskBig.txt", transferArgs.filename);
-    assertEquals("rule3", transferArgs.rulename);
-    assertEquals("no_information", transferArgs.fileinfo);
-    assertEquals(true, transferArgs.isMD5);
-    assertEquals(1000, transferArgs.blocksize);
-    assertNull(transferArgs.startTime);
-    assertEquals(1234, transferArgs.id);
+    assertEquals("hosta", transferArgs.getRemoteHost());
+    assertEquals("testTaskBig.txt", transferArgs.getFilename());
+    assertEquals("rule3", transferArgs.getRulename());
+    assertEquals("no_information", transferArgs.getFileinfo());
+    assertEquals(true, transferArgs.isMD5());
+    assertEquals(1000, transferArgs.getBlockSize());
+    assertNull(transferArgs.getStartTime());
+    assertEquals(1234, transferArgs.getId());
 
     // Check complete example
     String[] argsCompleteWithTimeStart = {
@@ -263,22 +266,23 @@ public class TransferArgsTest extends TestAbstract {
     transferArgs =
         AbstractTransfer.getParamsInternal(0, argsCompleteWithTimeStart);
     assertNotNull(transferArgs);
-    assertEquals("hosta", transferArgs.remoteHost);
-    assertEquals("testTaskBig.txt", transferArgs.filename);
-    assertEquals("rule3", transferArgs.rulename);
-    assertEquals("no_information", transferArgs.fileinfo);
-    assertEquals(true, transferArgs.isMD5);
-    assertEquals(1000, transferArgs.blocksize);
+    assertEquals("hosta", transferArgs.getRemoteHost());
+    assertEquals("testTaskBig.txt", transferArgs.getFilename());
+    assertEquals("rule3", transferArgs.getRulename());
+    assertEquals("no_information", transferArgs.getFileinfo());
+    assertEquals(true, transferArgs.isMD5());
+    assertEquals(1000, transferArgs.getBlockSize());
     Date date;
     final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyyMMddHHmmss");
     try {
       date = dateFormat.parse("20200601211201");
-      assertTrue(transferArgs.startTime.equals(new Timestamp(date.getTime())));
+      assertTrue(
+          transferArgs.getStartTime().equals(new Timestamp(date.getTime())));
     } catch (final ParseException ignored) {
       SysErrLogger.FAKE_LOGGER.ignoreLog(ignored);
       fail(ignored.getMessage());
     }
-    assertEquals(ILLEGALVALUE, transferArgs.id);
+    assertEquals(ILLEGALVALUE, transferArgs.getId());
 
     // Check complete example
     String[] argsCompleteWithDelay = {
@@ -290,17 +294,17 @@ public class TransferArgsTest extends TestAbstract {
     };
     transferArgs = AbstractTransfer.getParamsInternal(0, argsCompleteWithDelay);
     assertNotNull(transferArgs);
-    assertEquals("hosta", transferArgs.remoteHost);
-    assertEquals("testTaskBig.txt", transferArgs.filename);
-    assertEquals("rule3", transferArgs.rulename);
-    assertEquals("no_information", transferArgs.fileinfo);
-    assertEquals(true, transferArgs.isMD5);
-    assertEquals(1000, transferArgs.blocksize);
-    assertTrue(transferArgs.startTime
-                   .before(new Timestamp(System.currentTimeMillis() + 101)));
-    assertEquals(ILLEGALVALUE, transferArgs.id);
-    assertFalse(transferArgs.nolog);
-    assertFalse(transferArgs.normalInfoAsWarn);
+    assertEquals("hosta", transferArgs.getRemoteHost());
+    assertEquals("testTaskBig.txt", transferArgs.getFilename());
+    assertEquals("rule3", transferArgs.getRulename());
+    assertEquals("no_information", transferArgs.getFileinfo());
+    assertEquals(true, transferArgs.isMD5());
+    assertEquals(1000, transferArgs.getBlockSize());
+    assertTrue(transferArgs.getStartTime().before(
+        new Timestamp(System.currentTimeMillis() + 101)));
+    assertEquals(ILLEGALVALUE, transferArgs.getId());
+    assertFalse(transferArgs.isNolog());
+    assertFalse(transferArgs.isNormalInfoAsWarn());
 
     // Check complete example
     String[] argsCompleteWithNotLog = {
@@ -313,16 +317,16 @@ public class TransferArgsTest extends TestAbstract {
     transferArgs =
         AbstractTransfer.getParamsInternal(0, argsCompleteWithNotLog);
     assertNotNull(transferArgs);
-    assertEquals("hosta", transferArgs.remoteHost);
-    assertEquals("testTaskBig.txt", transferArgs.filename);
-    assertEquals("rule3", transferArgs.rulename);
-    assertEquals("no_information", transferArgs.fileinfo);
-    assertEquals(true, transferArgs.isMD5);
-    assertEquals(1000, transferArgs.blocksize);
-    assertTrue(transferArgs.nolog);
-    assertTrue(transferArgs.normalInfoAsWarn);
-    assertEquals(ILLEGALVALUE, transferArgs.id);
-    assertNull(transferArgs.follow);
+    assertEquals("hosta", transferArgs.getRemoteHost());
+    assertEquals("testTaskBig.txt", transferArgs.getFilename());
+    assertEquals("rule3", transferArgs.getRulename());
+    assertEquals("no_information", transferArgs.getFileinfo());
+    assertEquals(true, transferArgs.isMD5());
+    assertEquals(1000, transferArgs.getBlockSize());
+    assertTrue(transferArgs.isNolog());
+    assertTrue(transferArgs.isNormalInfoAsWarn());
+    assertEquals(ILLEGALVALUE, transferArgs.getId());
+    assertNull(transferArgs.getFollowId());
 
     // Check complete example
     String[] argsCompleteWithFollow = {
@@ -334,45 +338,80 @@ public class TransferArgsTest extends TestAbstract {
     transferArgs =
         AbstractTransfer.getParamsInternal(0, argsCompleteWithFollow);
     assertNotNull(transferArgs);
-    assertEquals("hosta", transferArgs.remoteHost);
-    assertEquals("testTaskBig.txt", transferArgs.filename);
-    assertEquals("rule3", transferArgs.rulename);
-    assertTrue(transferArgs.fileinfo
-                   .startsWith("no_information " + TransferArgs.FOLLOWARGJSON));
-    assertEquals(true, transferArgs.isMD5);
-    assertEquals(1000, transferArgs.blocksize);
-    assertFalse(transferArgs.nolog);
-    assertTrue(transferArgs.normalInfoAsWarn);
-    assertEquals(ILLEGALVALUE, transferArgs.id);
-    assertFalse(transferArgs.follow.isEmpty());
+    assertEquals("hosta", transferArgs.getRemoteHost());
+    assertEquals("testTaskBig.txt", transferArgs.getFilename());
+    assertEquals("rule3", transferArgs.getRulename());
+    logger.warn(transferArgs.getFileinfo());
+    assertTrue(transferArgs.getFileinfo().endsWith("no_information"));
+    assertTrue(transferArgs.getFileinfo().contains(FOLLOW_JSON_KEY));
+    assertEquals(true, transferArgs.isMD5());
+    assertEquals(1000, transferArgs.getBlockSize());
+    assertFalse(transferArgs.isNolog());
+    assertTrue(transferArgs.isNormalInfoAsWarn());
+    assertEquals(ILLEGALVALUE, transferArgs.getId());
+    assertFalse(transferArgs.getFollowId().isEmpty());
 
     // Check complete example
     String[] argsCompleteWithFollowIncluded = {
         TransferArgs.TO_ARG, "hosta", TransferArgs.FILE_ARG, "testTaskBig.txt",
         TransferArgs.RULE_ARG, "rule3", TransferArgs.HASH_ARG,
         TransferArgs.BLOCK_ARG, "1000", TransferArgs.FOLLOW_ARG,
-        TransferArgs.INFO_ARG, "no_information", TransferArgs.FOLLOWARGJSON,
-        "1234}"
+        TransferArgs.INFO_ARG, "no_information", FOLLOWARGJSON, "1234}"
     };
     transferArgs = TransferArgs
         .getParamsInternal(0, argsCompleteWithFollowIncluded, false);
     assertNotNull(transferArgs);
-    assertEquals("hosta", transferArgs.remoteHost);
-    assertEquals("testTaskBig.txt", transferArgs.filename);
-    assertEquals("rule3", transferArgs.rulename);
-    assertEquals("no_information", transferArgs.fileinfo);
-    assertEquals(true, transferArgs.isMD5);
-    assertEquals(1000, transferArgs.blocksize);
-    assertFalse(transferArgs.nolog);
-    assertTrue(transferArgs.normalInfoAsWarn);
-    assertEquals(ILLEGALVALUE, transferArgs.id);
-    assertTrue(transferArgs.follow.isEmpty());
-    assertNotEquals("1234", transferArgs.follow);
+    assertEquals("hosta", transferArgs.getRemoteHost());
+    assertEquals("testTaskBig.txt", transferArgs.getFilename());
+    assertEquals("rule3", transferArgs.getRulename());
+    assertEquals("no_information", transferArgs.getFileinfo());
+    assertEquals(true, transferArgs.isMD5());
+    assertEquals(1000, transferArgs.getBlockSize());
+    assertFalse(transferArgs.isNolog());
+    assertTrue(transferArgs.isNormalInfoAsWarn());
+    assertEquals(ILLEGALVALUE, transferArgs.getId());
+    assertTrue(transferArgs.getFollowId().isEmpty());
+    assertNotEquals("1234", transferArgs.getFollowId());
     TransferArgs
         .getAllInfo(transferArgs, 0, argsCompleteWithFollowIncluded, null);
-    assertEquals("1234", transferArgs.follow);
-    assertEquals("no_information " + TransferArgs.FOLLOWARGJSON + " 1234}",
-                 transferArgs.fileinfo);
+    logger.warn(transferArgs.getFileinfo());
+    assertEquals("1234", transferArgs.getFollowId());
+    assertTrue(transferArgs.getFileinfo().endsWith("no_information"));
+    assertTrue(transferArgs.getFileinfo().contains(FOLLOW_JSON_KEY));
+
+    String[] argsCompleteWithFollowIncludedAndMore = {
+        TransferArgs.TO_ARG, "hosta", TransferArgs.FILE_ARG, "testTaskBig.txt",
+        TransferArgs.RULE_ARG, "rule3", TransferArgs.HASH_ARG,
+        TransferArgs.BLOCK_ARG, "1000", TransferArgs.FOLLOW_ARG,
+        TransferArgs.INFO_ARG, "no_information", FOLLOWARGJSON,
+        "1234} {'key': 'value'} test after"
+    };
+    transferArgs = TransferArgs
+        .getParamsInternal(0, argsCompleteWithFollowIncludedAndMore, false);
+    assertNotNull(transferArgs);
+    assertEquals("hosta", transferArgs.getRemoteHost());
+    assertEquals("testTaskBig.txt", transferArgs.getFilename());
+    assertEquals("rule3", transferArgs.getRulename());
+    assertEquals("no_information", transferArgs.getFileinfo());
+    assertEquals(true, transferArgs.isMD5());
+    assertEquals(1000, transferArgs.getBlockSize());
+    assertFalse(transferArgs.isNolog());
+    assertTrue(transferArgs.isNormalInfoAsWarn());
+    assertEquals(ILLEGALVALUE, transferArgs.getId());
+    assertTrue(transferArgs.getFollowId().isEmpty());
+    assertNotEquals("1234", transferArgs.getFollowId());
+    TransferArgs
+        .getAllInfo(transferArgs, 0, argsCompleteWithFollowIncludedAndMore,
+                    null);
+    logger.warn(transferArgs.getFileinfo());
+    assertEquals("1234", transferArgs.getFollowId());
+    assertTrue(
+        transferArgs.getFileinfo().endsWith("no_information   test after"));
+    assertTrue(transferArgs.getFileinfo().contains(FOLLOW_JSON_KEY));
+    assertTrue(DbTaskRunner.getMapFromString(transferArgs.getFileinfo())
+                           .containsKey("key"));
+    assertTrue(DbTaskRunner.getMapFromString(transferArgs.getFileinfo())
+                           .containsKey(FOLLOW_JSON_KEY));
 
     String[] argsCompleteWithFollowCopied = {
         TransferArgs.TO_ARG, "hosta", TransferArgs.FILE_ARG, "testTaskBig.txt",
@@ -383,21 +422,23 @@ public class TransferArgsTest extends TestAbstract {
     transferArgs =
         TransferArgs.getParamsInternal(0, argsCompleteWithFollowCopied, false);
     assertNotNull(transferArgs);
-    assertEquals("hosta", transferArgs.remoteHost);
-    assertEquals("testTaskBig.txt", transferArgs.filename);
-    assertEquals("rule3", transferArgs.rulename);
-    assertEquals("no_information", transferArgs.fileinfo);
-    assertEquals(true, transferArgs.isMD5);
-    assertEquals(1000, transferArgs.blocksize);
-    assertFalse(transferArgs.nolog);
-    assertTrue(transferArgs.normalInfoAsWarn);
-    assertEquals(ILLEGALVALUE, transferArgs.id);
-    assertTrue(transferArgs.follow.isEmpty());
-    assertNotEquals("1234", transferArgs.follow);
+    assertEquals("hosta", transferArgs.getRemoteHost());
+    assertEquals("testTaskBig.txt", transferArgs.getFilename());
+    assertEquals("rule3", transferArgs.getRulename());
+    assertEquals("no_information", transferArgs.getFileinfo());
+    assertEquals(true, transferArgs.isMD5());
+    assertEquals(1000, transferArgs.getBlockSize());
+    assertFalse(transferArgs.isNolog());
+    assertTrue(transferArgs.isNormalInfoAsWarn());
+    assertEquals(ILLEGALVALUE, transferArgs.getId());
+    assertTrue(transferArgs.getFollowId().isEmpty());
+    assertNotEquals("1234", transferArgs.getFollowId());
     TransferArgs.getAllInfo(transferArgs, 0, argsCompleteWithFollowCopied,
-                            TransferArgs.FOLLOWARGJSON + " 1234}");
-    assertEquals("1234", transferArgs.follow);
-    assertEquals(TransferArgs.FOLLOWARGJSON + " 1234} " + "no_information " +
-                 "extra-info", transferArgs.fileinfo);
+                            FOLLOWARGJSON + " 1234}");
+    logger.warn(transferArgs.getFileinfo());
+    assertEquals("1234", transferArgs.getFollowId());
+    assertTrue(
+        transferArgs.getFileinfo().endsWith("no_information extra-info"));
+    assertTrue(transferArgs.getFileinfo().contains(FOLLOW_JSON_KEY));
   }
 } 

--- a/WaarpR66/src/test/java/org/waarp/openr66/pojo/TransferTest.java
+++ b/WaarpR66/src/test/java/org/waarp/openr66/pojo/TransferTest.java
@@ -182,6 +182,16 @@ public class TransferTest {
     logger.warn("{} = {} + {}", testMultipleMap2SameKeyAndNotMapEnding, map,
                 nomap);
 
+    String testMultipleMap2SameKeyAndTrueNotMapEnding =
+        "extra information {'key': 'value'} other" + " {'key2': 'value2'";
+    map = DbTaskRunner
+        .getMapFromString(testMultipleMap2SameKeyAndTrueNotMapEnding);
+    nomap = DbTaskRunner
+        .getOutOfMapFromString(testMultipleMap2SameKeyAndTrueNotMapEnding);
+    assertEquals("extra information  other {'key2': 'value2'", nomap);
+    assertEquals(1, map.size());
+    logger.warn("{} = {} + {}", testMultipleMap2SameKeyAndTrueNotMapEnding, map,
+                nomap);
   }
 
 }

--- a/WaarpR66/src/test/java/org/waarp/openr66/pojo/TransferTest.java
+++ b/WaarpR66/src/test/java/org/waarp/openr66/pojo/TransferTest.java
@@ -22,13 +22,20 @@ package org.waarp.openr66.pojo;
 
 import org.junit.Test;
 import org.waarp.common.json.JsonHandler;
+import org.waarp.common.logging.WaarpLogger;
+import org.waarp.common.logging.WaarpLoggerFactory;
 import org.waarp.openr66.context.ErrorCode;
+import org.waarp.openr66.database.data.DbTaskRunner;
 
 import java.sql.Timestamp;
+import java.util.Map;
 
 import static org.junit.Assert.*;
 
 public class TransferTest {
+  private static final WaarpLogger logger =
+      WaarpLoggerFactory.getLogger(TransferTest.class);
+
   @Test
   public void testJsonSerialisation() {
     Transfer transfer =
@@ -86,4 +93,95 @@ public class TransferTest {
 
     assertEquals(expected, got);
   }
+
+
+  @Test
+  public void testMapCapture() {
+    String testNoMap = "test1 test 2";
+    Map<String, Object> map = DbTaskRunner.getMapFromString(testNoMap);
+    String nomap = DbTaskRunner.getOutOfMapFromString(testNoMap);
+    assertEquals(testNoMap, nomap);
+    assertEquals(0, map.size());
+    logger.warn("{} = {} + {}", testNoMap, map, nomap);
+
+    String testSingleMap = "{}";
+    map = DbTaskRunner.getMapFromString(testSingleMap);
+    nomap = DbTaskRunner.getOutOfMapFromString(testSingleMap);
+    assertEquals("", nomap);
+    assertEquals(0, map.size());
+    logger.warn("{} = {} + {}", testSingleMap, map, nomap);
+
+    String testSingleMapKey = "{'key': 'value'}";
+    map = DbTaskRunner.getMapFromString(testSingleMapKey);
+    nomap = DbTaskRunner.getOutOfMapFromString(testSingleMapKey);
+    assertEquals("", nomap);
+    assertEquals(1, map.size());
+    logger.warn("{} = {} + {}", testSingleMapKey, map, nomap);
+
+    String testMultipleMap = "{} {}";
+    map = DbTaskRunner.getMapFromString(testMultipleMap);
+    nomap = DbTaskRunner.getOutOfMapFromString(testMultipleMap);
+    assertEquals(" ", nomap);
+    assertEquals(0, map.size());
+    logger.warn("{} = {} + {}", testMultipleMap, map, nomap);
+
+    String testMultipleMapKey = "{'key': 'value'} {}";
+    map = DbTaskRunner.getMapFromString(testMultipleMapKey);
+    nomap = DbTaskRunner.getOutOfMapFromString(testMultipleMapKey);
+    assertEquals(" ", nomap);
+    assertEquals(1, map.size());
+    logger.warn("{} = {} + {}", testMultipleMapKey, map, nomap);
+
+    String testMultipleMapKeyReverse = "{} {'key': 'value'} ";
+    map = DbTaskRunner.getMapFromString(testMultipleMapKeyReverse);
+    nomap = DbTaskRunner.getOutOfMapFromString(testMultipleMapKeyReverse);
+    assertEquals("  ", nomap);
+    assertEquals(1, map.size());
+    logger.warn("{} = {} + {}", testMultipleMapKeyReverse, map, nomap);
+
+    String testMultipleMapKeys =
+        "{} {'key': 'value'}{'key2': 'value'}{'key3': 'value'}";
+    map = DbTaskRunner.getMapFromString(testMultipleMapKeys);
+    nomap = DbTaskRunner.getOutOfMapFromString(testMultipleMapKeys);
+    assertEquals(" ", nomap);
+    assertEquals(3, map.size());
+    logger.warn("{} = {} + {}", testMultipleMapKeys, map, nomap);
+
+    String testMultipleMap2Key = "{'key': 'value'} {'key2': 'value2'}";
+    map = DbTaskRunner.getMapFromString(testMultipleMap2Key);
+    nomap = DbTaskRunner.getOutOfMapFromString(testMultipleMap2Key);
+    assertEquals(" ", nomap);
+    assertEquals(2, map.size());
+    logger.warn("{} = {} + {}", testMultipleMap2Key, map, nomap);
+
+    String testMultipleMap2SameKey = "{'key': 'value'} {'key': 'value2'}";
+    map = DbTaskRunner.getMapFromString(testMultipleMap2SameKey);
+    nomap = DbTaskRunner.getOutOfMapFromString(testMultipleMap2SameKey);
+    assertEquals(" ", nomap);
+    assertEquals(1, map.size());
+    logger.warn("{} = {} + {}", testMultipleMap2SameKey, map, nomap);
+
+    String testMultipleMap2SameKeyAndNotMap =
+        "extra information {'key': 'value'} other" +
+        "{'key2': 'value2'}and another one";
+    map = DbTaskRunner.getMapFromString(testMultipleMap2SameKeyAndNotMap);
+    nomap =
+        DbTaskRunner.getOutOfMapFromString(testMultipleMap2SameKeyAndNotMap);
+    assertEquals("extra information  other" + "and another one", nomap);
+    assertEquals(2, map.size());
+    logger.warn("{} = {} + {}", testMultipleMap2SameKeyAndNotMap, map, nomap);
+
+
+    String testMultipleMap2SameKeyAndNotMapEnding =
+        "extra information {'key': 'value'} other" + "{'key2': 'value2'}";
+    map = DbTaskRunner.getMapFromString(testMultipleMap2SameKeyAndNotMapEnding);
+    nomap = DbTaskRunner
+        .getOutOfMapFromString(testMultipleMap2SameKeyAndNotMapEnding);
+    assertEquals("extra information  other", nomap);
+    assertEquals(2, map.size());
+    logger.warn("{} = {} + {}", testMultipleMap2SameKeyAndNotMapEnding, map,
+                nomap);
+
+  }
+
 }

--- a/WaarpR66/src/test/java/org/waarp/openr66/protocol/junit/NetworkClientTest.java
+++ b/WaarpR66/src/test/java/org/waarp/openr66/protocol/junit/NetworkClientTest.java
@@ -786,8 +786,8 @@ public class NetworkClientTest extends TestAbstract {
         { "falsConfigFile", "-id", "" + specialId, "-to", "hostas" };
     TransferArgs transferArgs = SubmitTransferTest.getParamsInternal(1, args);
     if (transferArgs != null) {
-      String rule = transferArgs.rulename;
-      String localFilename = transferArgs.filename;
+      String rule = transferArgs.getRulename();
+      String localFilename = transferArgs.getFilename();
       logger.warn("Success for finding previous transfer {} {} {}", specialId,
                   rule, localFilename);
       final R66Future future2 = new R66Future(true);

--- a/WaarpR66/src/test/java/org/waarp/openr66/protocol/junit/NetworkClientTest.java
+++ b/WaarpR66/src/test/java/org/waarp/openr66/protocol/junit/NetworkClientTest.java
@@ -56,6 +56,7 @@ import org.waarp.openr66.client.RequestTransfer;
 import org.waarp.openr66.client.SpooledDirectoryTransfer;
 import org.waarp.openr66.client.SpooledDirectoryTransfer.Arguments;
 import org.waarp.openr66.client.SubmitTransfer;
+import org.waarp.openr66.client.TransferArgs;
 import org.waarp.openr66.context.ErrorCode;
 import org.waarp.openr66.context.R66FiniteDualStates;
 import org.waarp.openr66.context.R66Result;
@@ -783,9 +784,10 @@ public class NetworkClientTest extends TestAbstract {
     // Now second transfer based on ID
     String[] args =
         { "falsConfigFile", "-id", "" + specialId, "-to", "hostas" };
-    if (SubmitTransferTest.checkInternalParams(args)) {
-      String rule = SubmitTransferTest.getParamRule();
-      String localFilename = SubmitTransferTest.getParamLocalFilename();
+    TransferArgs transferArgs = SubmitTransferTest.getParamsInternal(1, args);
+    if (transferArgs != null) {
+      String rule = transferArgs.rulename;
+      String localFilename = transferArgs.filename;
       logger.warn("Success for finding previous transfer {} {} {}", specialId,
                   rule, localFilename);
       final R66Future future2 = new R66Future(true);
@@ -827,7 +829,7 @@ public class NetworkClientTest extends TestAbstract {
     }
     SubmitTransferTest.clearInternal();
     String[] args2 = { "falsConfigFile", "-id", "1", "-to", "hostas" };
-    assertFalse(SubmitTransferTest.checkInternalParams(args2));
+    assertNull(SubmitTransferTest.getParamsInternal(1, args2));
     final long time2 = System.currentTimeMillis();
     logger.warn("Success: " + success + " Error: " + error + " NB/s: " +
                 2 * success * 1000 / (time2 - time1));
@@ -2031,20 +2033,8 @@ public class NetworkClientTest extends TestAbstract {
             id, starttime);
     }
 
-    static public boolean checkInternalParams(String[] args) {
-      return getParamsInternal(args);
-    }
-
     static public void clearInternal() {
       clear();
-    }
-
-    static public String getParamRule() {
-      return rule;
-    }
-
-    static public String getParamLocalFilename() {
-      return localFilename;
     }
   }
 

--- a/WaarpR66/src/test/java/org/waarp/openr66/protocol/test/TestProgressBarTransfer.java
+++ b/WaarpR66/src/test/java/org/waarp/openr66/protocol/test/TestProgressBarTransfer.java
@@ -87,7 +87,7 @@ public class TestProgressBarTransfer extends ProgressBarTransfer {
     try {
       final TestProgressBarTransfer transaction =
           new TestProgressBarTransfer(future, rhost, localFilename, rule,
-                                      fileInfo, ismd5, block, idt,
+                                      transferInfo, ismd5, block, idt,
                                       networkTransaction, 100);
       transaction.normalInfoAsWarn = snormalInfoAsWarn;
       transaction.run();

--- a/WaarpR66/src/test/java/org/waarp/openr66/protocol/test/TestRecvThroughClient.java
+++ b/WaarpR66/src/test/java/org/waarp/openr66/protocol/test/TestRecvThroughClient.java
@@ -83,7 +83,8 @@ public class TestRecvThroughClient extends RecvThroughClient {
       final TestRecvThroughHandler handler = new TestRecvThroughHandler();
       final TestRecvThroughClient transaction =
           new TestRecvThroughClient(future, handler, rhost, localFilename, rule,
-                                    fileInfo, ismd5, block, networkTransaction);
+                                    transferInfo, ismd5, block,
+                                    networkTransaction);
       transaction.normalInfoAsWarn = snormalInfoAsWarn;
       final long time1 = System.currentTimeMillis();
       transaction.run();

--- a/WaarpR66/src/test/java/org/waarp/openr66/protocol/test/TestSendThroughClient.java
+++ b/WaarpR66/src/test/java/org/waarp/openr66/protocol/test/TestSendThroughClient.java
@@ -89,7 +89,8 @@ public class TestSendThroughClient extends SendThroughClient {
       final R66Future future = new R66Future(true);
       final TestSendThroughClient transaction =
           new TestSendThroughClient(future, rhost, localFilename, rule,
-                                    fileInfo, ismd5, block, networkTransaction);
+                                    transferInfo, ismd5, block,
+                                    networkTransaction);
       transaction.normalInfoAsWarn = snormalInfoAsWarn;
       final long time1 = System.currentTimeMillis();
       if (!transaction.initiateRequest()) {

--- a/WaarpR66/src/test/java/org/waarp/openr66/protocol/test/TestSendThroughForward.java
+++ b/WaarpR66/src/test/java/org/waarp/openr66/protocol/test/TestSendThroughForward.java
@@ -142,8 +142,8 @@ public class TestSendThroughForward extends SendThroughClient {
         new RequestPacket(transferArgs.getRulename(), mode,
                           transferArgs.getFilename(),
                           transferArgs.getBlockSize(), sourceRunner.getRank(),
-                          transferArgs.getId(), transferArgs.getFileinfo(), -1,
-                          sep);
+                          transferArgs.getId(), transferArgs.getTransferInfo(),
+                          -1, sep);
     // Not isRecv since it is the requester, so send => isSender is true
     final boolean isSender = true;
     try {

--- a/WaarpR66/src/test/java/org/waarp/openr66/protocol/test/TestSendThroughForward.java
+++ b/WaarpR66/src/test/java/org/waarp/openr66/protocol/test/TestSendThroughForward.java
@@ -123,9 +123,9 @@ public class TestSendThroughForward extends SendThroughClient {
     }
     DbRule rule;
     try {
-      rule = new DbRule(rulename);
+      rule = new DbRule(transferArgs.rulename);
     } catch (final WaarpDatabaseException e) {
-      logger.error("Cannot get Rule: " + rulename, e);
+      logger.error("Cannot get Rule: " + transferArgs.rulename, e);
       future.setResult(
           new R66Result(new OpenR66DatabaseGlobalException(e), null, true,
                         ErrorCode.Internal, null));
@@ -133,20 +133,23 @@ public class TestSendThroughForward extends SendThroughClient {
       return false;
     }
     int mode = rule.getMode();
-    if (isMD5) {
+    if (transferArgs.isMD5) {
       mode = RequestPacket.getModeMD5(mode);
     }
-    final String sep = PartnerConfiguration.getSeparator(remoteHost);
+    final String sep =
+        PartnerConfiguration.getSeparator(transferArgs.remoteHost);
     final RequestPacket request =
-        new RequestPacket(rulename, mode, filename, blocksize,
-                          sourceRunner.getRank(), id, fileinfo, -1, sep);
+        new RequestPacket(transferArgs.rulename, mode, transferArgs.filename,
+                          transferArgs.blocksize, sourceRunner.getRank(),
+                          transferArgs.id, transferArgs.fileinfo, -1, sep);
     // Not isRecv since it is the requester, so send => isSender is true
     final boolean isSender = true;
     try {
       try {
         // no delay
         taskRunner =
-            new DbTaskRunner(rule, isSender, request, remoteHost, null);
+            new DbTaskRunner(rule, isSender, request, transferArgs.remoteHost,
+                             null);
       } catch (final WaarpDatabaseException e) {
         logger.error("Cannot get task", e);
         future.setResult(

--- a/WaarpR66/src/test/java/org/waarp/openr66/protocol/test/TestSendThroughForward.java
+++ b/WaarpR66/src/test/java/org/waarp/openr66/protocol/test/TestSendThroughForward.java
@@ -123,9 +123,9 @@ public class TestSendThroughForward extends SendThroughClient {
     }
     DbRule rule;
     try {
-      rule = new DbRule(transferArgs.rulename);
+      rule = new DbRule(transferArgs.getRulename());
     } catch (final WaarpDatabaseException e) {
-      logger.error("Cannot get Rule: " + transferArgs.rulename, e);
+      logger.error("Cannot get Rule: " + transferArgs.getRulename(), e);
       future.setResult(
           new R66Result(new OpenR66DatabaseGlobalException(e), null, true,
                         ErrorCode.Internal, null));
@@ -133,23 +133,24 @@ public class TestSendThroughForward extends SendThroughClient {
       return false;
     }
     int mode = rule.getMode();
-    if (transferArgs.isMD5) {
+    if (transferArgs.isMD5()) {
       mode = RequestPacket.getModeMD5(mode);
     }
     final String sep =
-        PartnerConfiguration.getSeparator(transferArgs.remoteHost);
+        PartnerConfiguration.getSeparator(transferArgs.getRemoteHost());
     final RequestPacket request =
-        new RequestPacket(transferArgs.rulename, mode, transferArgs.filename,
-                          transferArgs.blocksize, sourceRunner.getRank(),
-                          transferArgs.id, transferArgs.fileinfo, -1, sep);
+        new RequestPacket(transferArgs.getRulename(), mode,
+                          transferArgs.getFilename(),
+                          transferArgs.getBlockSize(), sourceRunner.getRank(),
+                          transferArgs.getId(), transferArgs.getFileinfo(), -1,
+                          sep);
     // Not isRecv since it is the requester, so send => isSender is true
     final boolean isSender = true;
     try {
       try {
         // no delay
-        taskRunner =
-            new DbTaskRunner(rule, isSender, request, transferArgs.remoteHost,
-                             null);
+        taskRunner = new DbTaskRunner(rule, isSender, request,
+                                      transferArgs.getRemoteHost(), null);
       } catch (final WaarpDatabaseException e) {
         logger.error("Cannot get task", e);
         future.setResult(

--- a/WaarpR66/src/test/java/org/waarp/openr66/protocol/test/TestSubmitTransfer.java
+++ b/WaarpR66/src/test/java/org/waarp/openr66/protocol/test/TestSubmitTransfer.java
@@ -75,7 +75,7 @@ public class TestSubmitTransfer extends SubmitTransfer {
       }
       final TestSubmitTransfer transaction =
           new TestSubmitTransfer(arrayFuture[i], rhost, localFilename, rule,
-                                 fileInfo, ismd5, block, newstart);
+                                 transferInfo, ismd5, block, newstart);
       transaction.normalInfoAsWarn = snormalInfoAsWarn;
       // executorService.execute(transaction);
       transaction.run();

--- a/WaarpR66/src/test/java/org/waarp/openr66/protocol/test/TestTransferNoDb.java
+++ b/WaarpR66/src/test/java/org/waarp/openr66/protocol/test/TestTransferNoDb.java
@@ -110,7 +110,7 @@ public class TestTransferNoDb extends DirectTransfer {
         arrayFuture[i] = new R66Future(true);
         final TestTransferNoDb transaction =
             new TestTransferNoDb(arrayFuture[i], rhost, localFilename, rule,
-                                 fileInfo, ismd5, block,
+                                 transferInfo, ismd5, block,
                                  DbConstantR66.ILLEGALVALUE,
                                  networkTransaction);
         transaction.normalInfoAsWarn = snormalInfoAsWarn;

--- a/doc/waarp-r66/source/changes.rst
+++ b/doc/waarp-r66/source/changes.rst
@@ -7,6 +7,39 @@ La procédure de mise à jour est disponible ici: :any:`upgrade`
 Non publié
 ==========
 
+Waarp R66 3.4.0 (2020-06-22)
+============================
+
+Nouvelles fonctionnalités
+=========================
+
+- [`#49 <https://github.com/waarp/Waarp-All/pull/49>`__]
+  Pour les transferts, une nouvelle option `-follow` permet de gérer le suivi
+  fin des retransferts (rebonds entre plusieurs serveurs R66). Cette option
+  positionne un champ dans la partie `information de transfert` de la forme
+  suivante : `{'follow': numeroUnique}` pour le premier transfert et les
+  transferts suivants récupèreront ainsi cette information nativement.
+- [`#48 <https://github.com/waarp/Waarp-All/pull/48>`__]
+  Une nouvelle tâche nommée `ICAP` est créée afin de permettre  l'échange avec
+  un serveur répondant à la norme RFC 3507 dite `ICAP`.
+  Elle permet de transférer le contenu du fichier vers un service ICAP via une
+  commande `RESPMOD` et d'obtenir la validation de ce fichier par le service
+  (status `204`).
+
+Correctifs
+==========
+
+- Le log géré par LogBack génère parfois des logs au démarrage d'information
+  ou de debug qui peuvent être évités (en conservant les Warnings et les Erreurs)
+  via l'ajout dans le fichier de configuration `logback.xml` les paramètres
+  suivants :
+
+.. code-block:: xml
+
+  <statusListener
+    class="org.waarp.common.logging.PrintOnlyWarningLogbackStatusListener" />
+
+
 Waarp R66 3.3.4 (2020-06-02)
 ============================
 

--- a/doc/waarp-r66/source/changes.rst
+++ b/doc/waarp-r66/source/changes.rst
@@ -7,14 +7,14 @@ La procédure de mise à jour est disponible ici: :any:`upgrade`
 Non publié
 ==========
 
-Waarp R66 3.4.0 (2020-06-22)
+Waarp R66 3.4.0 (2020-07-01)
 ============================
 
 Nouvelles fonctionnalités
 =========================
 
 - [`#49 <https://github.com/waarp/Waarp-All/pull/49>`__]
-  Pour les transferts, une nouvelle option ``-follow`` permet de gérer le suivi
+  Pour les transferts, une nouvelle fonctionnalité permet de gérer le suivi
   fin des retransferts (rebonds entre plusieurs serveurs R66). Cette option
   positionne un champ dans la partie ``information de transfert`` de la forme
   suivante : ``{"follow": numeroUnique}`` pour le premier transfert et les
@@ -24,6 +24,10 @@ Nouvelles fonctionnalités
   en spécifiant pour le premier transfert dans le champ ``-info`` (``information de transfert``)
   un Json de type ``{"follow": numeroUnique}`` en attribuant un numéro unique
   (comme un timestamp).
+
+  Cette option est active par défaut. Pour la désactiver, il faut préciser l'option
+  ``-nofolow``.
+
 - L'interface REST V2 intègre l'option de recherche par ``followId``
   (``GET /v2/transfers/?followId=number``). ``number`` étant possiblement un entier
   long, il est conseillé de le manipuler en chaîne de caractères.

--- a/doc/waarp-r66/source/changes.rst
+++ b/doc/waarp-r66/source/changes.rst
@@ -14,25 +14,38 @@ Nouvelles fonctionnalités
 =========================
 
 - [`#49 <https://github.com/waarp/Waarp-All/pull/49>`__]
-  Pour les transferts, une nouvelle option `-follow` permet de gérer le suivi
+  Pour les transferts, une nouvelle option ``-follow`` permet de gérer le suivi
   fin des retransferts (rebonds entre plusieurs serveurs R66). Cette option
-  positionne un champ dans la partie `information de transfert` de la forme
-  suivante : `{'follow': numeroUnique}` pour le premier transfert et les
+  positionne un champ dans la partie ``information de transfert`` de la forme
+  suivante : ``{"follow": numeroUnique}`` pour le premier transfert et les
   transferts suivants récupèreront ainsi cette information nativement.
+
+  Pour les anciennes versions, il est possible de simuler cette option manuellement
+  en spécifiant pour le premier transfert dans le champ ``-info`` (``information de transfert``)
+  un Json de type ``{"follow": numeroUnique}`` en attribuant un numéro unique
+  (comme un timestamp).
+- L'interface REST V2 intègre l'option de recherche par ``followId``
+  (``GET /v2/transfers/?followId=number``). ``number`` étant possiblement un entier
+  long, il est conseillé de le manipuler en chaîne de caractères.
+
+  Pour les anciennes versions, il faut requêter tous les transferts et filtrer ensuite
+  sur le champ ``transferInformation`` selon la présence d'un champ ``follow`` suivi
+  d'un numéro au format Json.
 - [`#48 <https://github.com/waarp/Waarp-All/pull/48>`__]
-  Une nouvelle tâche nommée `ICAP` est créée afin de permettre  l'échange avec
-  un serveur répondant à la norme RFC 3507 dite `ICAP`.
+  Une nouvelle tâche nommée ``ICAP`` est créée afin de permettre  l'échange avec
+  un serveur répondant à la norme RFC 3507 dite ``ICAP``.
   Elle permet de transférer le contenu du fichier vers un service ICAP via une
-  commande `RESPMOD` et d'obtenir la validation de ce fichier par le service
-  (status `204`).
+  commande ``RESPMOD`` et d'obtenir la validation de ce fichier par le service
+  (status ``204``).
 
 Correctifs
 ==========
 
-- Le log géré par LogBack génère parfois des logs au démarrage d'information
+- [`#50 <https://github.com/waarp/Waarp-All/pull/50>`__]
+  Le log géré par LogBack génère parfois des logs au démarrage d'information
   ou de debug qui peuvent être évités (en conservant les Warnings et les Erreurs)
-  via l'ajout dans le fichier de configuration `logback.xml` les paramètres
-  suivants :
+  via l'ajout dans le fichier de configuration ``logback.xml`` les paramètres
+  suivants en tête des options :
 
 .. code-block:: xml
 

--- a/doc/waarp-r66/source/configuration-details/detail-tasks.rst
+++ b/doc/waarp-r66/source/configuration-details/detail-tasks.rst
@@ -521,6 +521,10 @@ ICAP
   Une documentation complète d'installation au regard des interactions avec un serveur ICAP est disponible
   :any:`ici <setup-icap>`
 
+Cette tâche permet l'échange avec un serveur répondant à la norme RFC 3507 dite `ICAP`.
+Elle permet de transférer le contenu du fichier vers un service ICAP via une commande
+`RESPMOD` et d'obtenir la validation de ce fichier par le service (status `204`).
+
 La liste des arguments est la suivante :
 
 * ``-file filename`` spécifie le chemin du fichier sur lequel opérer (si le nom
@@ -861,11 +865,26 @@ Soumet un nouveau transfert basé sur des arguments ``Path`` et ``Transfer Infor
 - ``Delay`` est ignoré
 - Le fichier n'est pas marqué comme déplacé.
 
+Arguments du transfert :
+
 ::
 
-  -file filepath -to requestedHost -rule rule [-md5]
-  [-start yyyyMMddHHmmss or -delay (delay or +delay)]
-  [-copyinfo] [-info transferInformation]
+  -to <arg>        Spécifie le partenaire distant
+  (-id <arg>|      Spécifie l'identifiant du transfert
+   (-file <arg>    Spécifie le fichier à opérer
+    -rule <arg>))  Spécifie la règle de transfert
+  [-block <arg>]   Spécifie la taille du bloc
+  [-follow]        Spécifie que le trasfert doit intégrer un "follow" id
+  [-md5]           Spécifie qu'un calcul d'empreinte doit être réalisé pour
+                    valider le transfert
+  [-delay <arg>|   Spécifie le délai comme un temps epoch ou un délai (+arg) en ms
+   -start <arg>]   Spécifie la date de démarrage yyyyMMddHHmmss
+  [-nolog]         Spécifie de ne rien conserver de ce transfert (en base)
+  [-notlogWarn |   Spécifie que le log final est en mode Info si OK
+   -logWarn]       Spécifie que le log final est en mode Warn si OK (défaut)
+  [-copyinfo]      Spécifie que les informations de transfert seront recopiées
+                    intégralement en préposition des nouvelles valeurs
+  [-info <arg>)    Spécifie les informations de transfert (en dernière position)
 
 
 Exemple:

--- a/doc/waarp-r66/source/configuration-details/detail-tasks.rst
+++ b/doc/waarp-r66/source/configuration-details/detail-tasks.rst
@@ -2,6 +2,90 @@
 Type de Task
 ############
 
+Format général d'une tâche
+--------------------------
+
+Une tâche est définie selon un format unifié XML :
+
+.. code-block:: xml
+
+  <tasks>
+   <task>
+    <type>NAME</type>
+    <path>path</path>
+    <delay>x</delay>
+    <rank>n</rank>
+   </task>
+  </tasks>
+
+- ``Type`` est l'identifiant du type de tâche à exécuter (les types sont présentés ci-après.
+
+- ``Path`` est un argument fixé par la règle et dont des remplacements de mots clefs sont opérés :
+
+  - ``#TRUEFULLPATH#`` : Chemin complet du fichier courant
+  - ``#TRUEFILENAME#`` : Nom du fichier courant (hors chemin) (différent côté réception)
+  - ``#ORIGINALFULLPATH#`` : Chemin complet du fichier d'origine (avant changement côté réception)
+  - ``#ORIGINALFILENAME#`` : Nom du fichier d'origine (avant changement côté réception)
+  - ``#FILESIZE#`` : Taille du fichier s'il existe
+  - ``#INPATH#`` : Chemin du dossier de réception
+  - ``#OUTPATH#`` : Chemin du dossier d'émission
+  - ``#WORKPATH#`` : Chemin du dossier de travail
+  - ``#ARCHPATH#`` : Chemin du dossier d'archive
+  - ``#HOMEPATH#`` : Chemin du dossier du répertoire "racine" de Waarp
+  - ``#RULE#`` : Règle utilisé pour le transfert
+  - ``#DATE#`` : Date courante au format yyyyMMdd
+  - ``#HOUR#`` : Heure courante au format HHmmss
+  - ``#REMOTEHOST#`` : Nom DNS du partenaire
+  - ``#REMOTEHOSTIP#`` : IP du partenaire
+  - ``#LOCALHOST#`` : Nom DNS local du serveur Waarp
+  - ``#LOCALHOSTIP#`` : IP du serveur Waarp
+  - ``#TRANSFERID#`` : Identifiant de transfert
+  - ``#REQUESTERHOST#`` : Nom du partenaire initiateur du transfert
+  - ``#REQUESTEDHOST#`` : Nom du partenaire recevant la demande de transfert
+  - ``#FULLTRANSFERID#`` : Identifiant complet du transfert comme ``TRANSFERID_REQUESTERHOST_REQUESTEDHOST``
+  - ``#RANKTRANSFER#`` : Rang du bloc courant ou final du fichier transféré
+  - ``#BLOCKSIZE#`` : Taille du bloc utilisé
+  - ``#ERRORMSG#`` : Le message d'erreur courant ou "NoError" si aucune erreur n'a été levée jusqu'à cet
+    appel
+  - ``#ERRORCODE#`` : Le code erreur courant ou ``-`` (``Unknown``) si aucune erreur n'a été levée jusqu'à
+    cet appel
+  - ``#ERRORSTRCODE#`` : Le message lié au code d'erreur courant ou ``Unknown`` si aucune erreur n'a été
+    levée jusqu'à cet appel
+  - ``#NOWAIT#`` : Utilisé par la tâche EXEC pour spécifier que la commande est à exécuter en mode asynchrone,
+    sans en attendre le résultat
+  - ``#LOCALEXEC#`` : Utilisé par la tâche EXEC pour spécifier que la commande est à exécuter de manière
+    distante (pas dans la JVM courante) mais au travers d'un démon ``LocalExec`` (spécifié dans la
+    configuration globale
+
+Par exemple, un ``Path`` défini comme :
+``some #DATE# some2 #TRANSFERID# some3 #REMOTEHOST# some4``
+donnera
+``some 20130529 some2 123456789123 some3 remotehostid some4``
+
+- ``Delay`` est généralement le délai (si précisé) maximum pour l'exécution d'une tâche avant qu'elle tombe
+  en erreur pour dépassement de délai.
+- ``Rank`` est optionnel et permet d'indiquer un rang d'exécution des tâches, laissant une souplesse sur
+  l'ordre d'écriture en période de tests. Il n'est pas conseillé de l'utiliser par défaut hormis pour les
+  tests et validation de plusieurs tâches.
+
+De plus, une tâche utilisera les arguments de transfert eux-même (``Transfer Information``) pour déduire
+les paramètres finaux en utilisant la fonction
+``String.format(path règle, info transfert.éclaté en sous chaînes via le séparateur " ")``
+
+L'argument de transfert (spécifié par ``-info`` dans les commandes de transferts) ou le ``path`` peuvent
+contenir une MAP au format JSON qui intègre des éléments utiles aux tâches ou au fonctionnement de Waarp
+(comme le ``DIGEST``, le ``RESCHDEDULE``, l'option ``-follow``).
+
+Ceci permet de rendre les arguments très adaptatifs.
+
+Par exemple :
+
+- si la règle définie ``Path`` comme ``some %s some2 %d some3 %s some4``
+- et si les informations de transferts sont ``info1 1 info2``
+- Le résultat sera pour cette tâche : ``some info1 some2 1 some3 info2 some4``
+
+
+
 Tâches informatives
 -------------------
 

--- a/doc/waarp-r66/source/configuration-details/detail-tasks.rst
+++ b/doc/waarp-r66/source/configuration-details/detail-tasks.rst
@@ -74,7 +74,7 @@ les paramètres finaux en utilisant la fonction
 
 L'argument de transfert (spécifié par ``-info`` dans les commandes de transferts) ou le ``path`` peuvent
 contenir une MAP au format JSON qui intègre des éléments utiles aux tâches ou au fonctionnement de Waarp
-(comme le ``DIGEST``, le ``RESCHDEDULE``, l'option ``-follow``).
+(comme le ``DIGEST``, le ``RESCHDEDULE``, l'option ``follow``).
 
 Ceci permet de rendre les arguments très adaptatifs.
 
@@ -958,7 +958,7 @@ Arguments du transfert :
    (-file <arg>    Spécifie le fichier à opérer
     -rule <arg>))  Spécifie la règle de transfert
   [-block <arg>]   Spécifie la taille du bloc
-  [-follow]        Spécifie que le trasfert doit intégrer un "follow" id
+  [-nofollow]      Spécifie que le trasfert ne devra pas intégrer un "follow" id
   [-md5]           Spécifie qu'un calcul d'empreinte doit être réalisé pour
                     valider le transfert
   [-delay <arg>|   Spécifie le délai comme un temps epoch ou un délai (+arg) en ms

--- a/doc/waarp-r66/source/interface/restv2/OAS30-RESTv2_fr.yaml
+++ b/doc/waarp-r66/source/interface/restv2/OAS30-RESTv2_fr.yaml
@@ -108,6 +108,11 @@ paths:
           schema:
             type: string
             format: date-time
+        - name: followId
+          in: query
+          description: Identifiant FollowId à rechercher dans les transferts.
+          schema:
+            type: string
     post:
       responses:
         '201':

--- a/doc/waarp-r66/source/interface/restv2/transfers/list.yaml
+++ b/doc/waarp-r66/source/interface/restv2/transfers/list.yaml
@@ -108,6 +108,11 @@ paths:
           schema:
             type: string
             format: date-time
+        - name: followId
+          in: query
+          description: Identifiant FollowId à rechercher dans les transferts.
+          schema:
+            type: string
 components:
   schemas:
     ObjectTransfer:

--- a/pom.xml
+++ b/pom.xml
@@ -229,7 +229,7 @@
     <!-- Waarp Versions -->
     <waarp.directory.version>test</waarp.directory.version>
     <waarp.module.version>test</waarp.module.version>
-    <waarp.version>3.4.0-dev</waarp.version>
+    <waarp.version>3.4.0</waarp.version>
     <revision>${waarp.version}</revision>
 
     <!-- Dependencies versions -->


### PR DESCRIPTION
- Option `follow`

This option `follow` allows to add a specific field in the transfer information such that
in an externa tool, it is possible to link multiple transfers as hop of the same file.

For instance, sending a file from host A to host B, which will autoatically resend this file
to host C, and then to host D, all transfers will have a special information within the
transfer information such as `{'follow': number}`. This number will be kept the same
in each and every transfers related to the first one.

This option is enabled by default. Then, for the first transfer, Waarp will allocate
a new specific Id of follow. Then all other transfers related to the first one will
have this one.

If yoy don't want this option enabled, just add `-nofollow` option.

- Add Rest V2 options for FollowId
    
The REST V2 interface integrates the search options based on `followId`
(`GET /v2/transfers/?followId=number`).
    
`number` being possibly a long number, it is adviced to manipulate
it as a String.
    
Add a special finder in DbTaskRunner for this
(`getSelectSameFollowId(followId, orderByStart, limit)`).
    
Fix also Map manipulation within Transfer Information to not loose other informations
than JSON extra information (various usages).

Note, for old versions, it is possible to simulate this option by doing the
following:
- Only for the first transfer, add to the `-info` transfer option a map as
`{"follow": uniqueNumber}` with a unique number such as nanotime or timestamp.
- To request on old versions, one should request all transfers (filtering on date
for instance) and post filtering them on the presence in the `transferInfo` field
of such a Json map.