### PR TITLE
[R66] the file watcher regex are tested only against a full path

### DIFF
--- a/WaarpCommon/src/main/java/org/waarp/common/filemonitor/RegexFileFilter.java
+++ b/WaarpCommon/src/main/java/org/waarp/common/filemonitor/RegexFileFilter.java
@@ -50,7 +50,7 @@ public class RegexFileFilter implements FileFilter {
   public boolean accept(File pathname) {
     if (pathname.isFile()) {
       if (pattern != null) {
-        return pattern.matcher(pathname.getPath()).matches() &&
+        return pattern.matcher(pathname.getPath()).find() &&
                (minimalSize == 0 || pathname.length() >= minimalSize);
       }
       return minimalSize == 0 || pathname.length() >= minimalSize;

--- a/WaarpCommon/src/test/java/org/waarp/common/filemonitor/RegexFileFilterTest.java
+++ b/WaarpCommon/src/test/java/org/waarp/common/filemonitor/RegexFileFilterTest.java
@@ -1,0 +1,180 @@
+/*
+ * This file is part of Waarp Project (named also Waarp or GG).
+ *
+ *  Copyright (c) 2020, Waarp SAS, and individual contributors by the @author
+ *  tags. See the COPYRIGHT.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ *  All Waarp Project is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * Waarp is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ * Waarp . If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.waarp.common.filemonitor;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.junit.Test;
+
+/**
+ * RegexFileFilterTest regroups unit tests for {@link RegexFileFilter}.
+ */
+public class RegexFileFilterTest {
+  @Test
+  public void testRegexFilename() {
+    String rx = "test.csv";
+    RegexFileFilter rff = new RegexFileFilter(rx);
+    String[] shouldMatch = {"test.csv", "subdir/test.csv"};
+    String[] shouldNotMatch = {"foo.csv", "subdir/foo.csv"};
+
+    for (String s: shouldMatch) {
+      assertTrue("RegexFileFilter with regex '"+rx+"' should match '"+ s +"'",
+                 doTestOnPath(rff, s));
+    }
+
+    for (String s: shouldNotMatch) {
+      assertFalse("RegexFileFilter with regex '"+rx+"' should match '"+ s +"'",
+                  doTestOnPath(rff, s));
+    }
+  }
+
+  @Test
+  public void testRegexFilenameWildcard() {
+    String rx = ".*\\.csv";
+    RegexFileFilter rff = new RegexFileFilter(rx);
+    String[] shouldMatch = {"test.csv", "subdir/test.csv"};
+    String[] shouldNotMatch = {"foo.txt", "subdir/foo.txt"};
+
+    for (String s: shouldMatch) {
+      assertTrue("RegexFileFilter with regex '"+rx+"' should match '"+ s +"'",
+                 doTestOnPath(rff, s));
+    }
+
+    for (String s: shouldNotMatch) {
+      assertFalse("RegexFileFilter with regex '"+rx+"' should match '"+ s +"'",
+                  doTestOnPath(rff, s));
+    }
+  }
+
+  @Test
+  public void testRegexPathPrefix() {
+    String rx = "subdir/.*";
+    RegexFileFilter rff = new RegexFileFilter(rx);
+    String[] shouldMatch = {
+      "subdir/test.csv", "subdir/foo.csv",
+      "dir/subdir/foo.txt", "othersubdir/test.csv",
+      "subdir/otherdir/test.csv",
+    };
+    String[] shouldNotMatch = {"foo.csv", "otherdir/foo.csv"};
+
+    for (String s: shouldMatch) {
+      assertTrue("RegexFileFilter with regex '"+rx+"' should match '"+ s +"'",
+                 doTestOnPath(rff, s));
+    }
+
+    for (String s: shouldNotMatch) {
+      assertFalse("RegexFileFilter with regex '"+rx+"' should match '"+ s +"'",
+                  doTestOnPath(rff, s));
+    }
+  }
+
+  @Test
+  public void testRegexPathAbsolutePrefix() {
+    String rx = "^subdir/.*";
+    RegexFileFilter rff = new RegexFileFilter(rx);
+    String[] shouldMatch = {
+      "subdir/test.csv",
+      "subdir/foo.csv",
+      "subdir/otherdir/test.csv",
+    };
+    String[] shouldNotMatch = {
+      "foo.csv",
+      "otherdir/foo.csv",
+      "dir/subdir/foo.txt",
+      "othersubdir/test.csv",
+    };
+
+    for (String s: shouldMatch) {
+      assertTrue("RegexFileFilter with regex '"+rx+"' should match '"+ s +"'",
+                 doTestOnPath(rff, s));
+    }
+
+    for (String s: shouldNotMatch) {
+      assertFalse("RegexFileFilter with regex '"+rx+"' should match '"+ s +"'",
+                  doTestOnPath(rff, s));
+    }
+  }
+
+  @Test
+  public void testRegexWithFlags() {
+    String rx = "(?i)subdir/.*";
+    RegexFileFilter rff = new RegexFileFilter(rx);
+    String[] shouldMatch = {
+      "subdir/test.csv",
+      "SUBDIR/foo.csv",
+      "subDiR/otherdir/test.csv",
+    };
+    String[] shouldNotMatch = {
+      "foo.csv",
+      "otherdir/foo.csv",
+    };
+
+    for (String s: shouldMatch) {
+      assertTrue("RegexFileFilter with regex '"+rx+"' should match '"+ s +"'",
+                 doTestOnPath(rff, s));
+    }
+
+    for (String s: shouldNotMatch) {
+      assertFalse("RegexFileFilter with regex '"+rx+"' should match '"+ s +"'",
+                  doTestOnPath(rff, s));
+    }
+  }
+
+
+  private boolean doTestOnPath(RegexFileFilter rff, String path) {
+    try {
+      setupStubPath(path);
+
+      return rff.accept(new File(path));
+
+    } catch (IOException e) {
+      fail("cannot create stub test file '"+path+"':"+e);
+    } finally {
+      tearDownStubFile(path);
+    }
+
+    return false;
+  }
+
+  private void setupStubPath(String path) throws IOException {
+    File f = new File(path);
+
+    if (path.contains("/")) {
+      f.getParentFile().mkdirs();
+    }
+
+    f.createNewFile();
+  }
+
+  private void tearDownStubFile(String path) {
+    File tmpFile = new File(path);
+
+    if (tmpFile.exists()) {
+      tmpFile.delete();
+    }
+
+    if (path.contains("/")) {
+      tmpFile.getParentFile().delete();
+    }
+  }
+}

--- a/doc/waarp-r66/source/changes.rst
+++ b/doc/waarp-r66/source/changes.rst
@@ -42,6 +42,18 @@ Nouvelles fonctionnalités
   commande ``RESPMOD`` et d'obtenir la validation de ce fichier par le service
   (status ``204``).
 
+Évolutions
+==========
+
+- [`#51 <https://github.com/waarp/Waarp-All/pull/51>`__] Les valeurs par défaut
+  des limitations de bande passante ont changées : La limitation globale par
+  défaut est maintenant de 100Gbps, et celle par connexion est de 1Gbps (ces
+  valeurs peuvent être ajustées dans les fichiers de configuration).
+- [`#51 <https://github.com/waarp/Waarp-All/pull/51>`__] La valeur par défaut
+  de la RAM maximale utilisée par les services WEB et REST a été abaissée à 1Go
+  (au lieu de 4Go) (cette valeur peut être ajustée dans les fichiers de
+  configuration).
+
 Correctifs
 ==========
 
@@ -64,15 +76,12 @@ Correctifs
 - [`#51 <https://github.com/waarp/Waarp-All/pull/51>`__] Si aucun argument
   ``-Xms`` n'est passé à la JVM lors du démarrage, la valeur par défaut de la
   JVM s'applique (en général 4Go).
-- [`#51 <https://github.com/waarp/Waarp-All/pull/51>`__] Les valeurs par défaut
-  des limitations de bande passante ont changées : La limitation globale par
-  défaut est maintenant de 100Gbps, et celle par connexion est de 1Gbps (ces
-  valeurs peuvent être ajustées dans les fichiers de configuration).
-- [`#51 <https://github.com/waarp/Waarp-All/pull/51>`__] La valeur par défaut
-  de la RAM maximale utilisée par les services WEB et REST a été abaissée à 1Go
-  (au lieu de 4Go) (cette valeur peut être ajustée dans les fichiers de
-  configuration).
+- [`#54 <https://github.com/waarp/Waarp-All/pull/54>`__] Prise en charge
+  correcte du filtrage par expression régulière dans le *file watcher* (il
+  était impossible de filtrer juste sur le nom d'un fichier situé dans un
+  sous-dossier).
 - Mise à jour des dépendances
+
 
 Waarp R66 3.3.4 (2020-06-02)
 ============================

--- a/doc/waarp-r66/source/interface/restv2/index.rst
+++ b/doc/waarp-r66/source/interface/restv2/index.rst
@@ -7,10 +7,10 @@ ATTENTION: L'API REST v2 est actuellement en beta et est donc susceptible de con
 Cette documentation ayant pour but d'être courte et concise, en conséquence elle peut parfois manquer de
 précision.
 En cas de besoin, une documentation un peu plus exhaustive peut être consultée 
-`ici </_static/restv2/html/index.html#docs/summary/summary>`_.
+`ici <../../_static/restv2/html/index.html#docs/summary/summary>`_.
 
 Une specification détaillée écrite en RAML peut également être téléchargée si nécessaire en utilisant
-:download:`ce lien </_static/restv2/RAML10-RESTv2_fr.yaml>`.
+:download:`ce lien <../../_static/restv2/RAML10-RESTv2_fr.yaml>`.
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
Originally, the regex filtering in the filewatcher was only able to match filenames. 
In recursive mode, it was impossible to math a subpath.

During the 3.1 development cycle, I pushed some changes to match full paths. However, this had the side-effect to only allow file matching if the regex started with `.*` to match the subpath (ex: `.*.csv`). I.e. the regex `myfile\.txt` whould not match `subpath/myfile.txt`.

This PR allows both regex to work as expected:
- `myfile\.txt` matches `myfile.txt` as well as `subpath/myfile.txt`
- `subdir/.+\.txt` matches `subdir/myfile.txt`