### PR TITLE
Get Oracle JDBC driver from Maven Central

### DIFF
--- a/WaarpCommon/pom.xml
+++ b/WaarpCommon/pom.xml
@@ -99,7 +99,7 @@
       <artifactId>mysql-connector-java</artifactId>
     </dependency>
     <dependency>
-      <groupId>Oracle</groupId>
+      <groupId>com.oracle.database.jdbc</groupId>
       <artifactId>ojdbc6</artifactId>
       <optional>true</optional>
     </dependency>

--- a/WaarpGatewayFtp/pom.xml
+++ b/WaarpGatewayFtp/pom.xml
@@ -88,7 +88,7 @@
       <artifactId>netty-tcnative-boringssl-static</artifactId>
     </dependency>
     <dependency>
-      <groupId>Oracle</groupId>
+      <groupId>com.oracle.database.jdbc</groupId>
       <artifactId>ojdbc6</artifactId>
       <optional>true</optional>
     </dependency>

--- a/WaarpHttp/pom.xml
+++ b/WaarpHttp/pom.xml
@@ -141,7 +141,7 @@
       <artifactId>netty-http-java6</artifactId>
     </dependency>
     <dependency>
-      <groupId>Oracle</groupId>
+      <groupId>com.oracle.database.jdbc</groupId>
       <artifactId>ojdbc6</artifactId>
       <optional>true</optional>
     </dependency>

--- a/WaarpR66/pom.xml
+++ b/WaarpR66/pom.xml
@@ -141,7 +141,7 @@
       <artifactId>netty-http-java6</artifactId>
     </dependency>
     <dependency>
-      <groupId>Oracle</groupId>
+      <groupId>com.oracle.database.jdbc</groupId>
       <artifactId>ojdbc6</artifactId>
       <optional>true</optional>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -287,7 +287,7 @@
 		<commons-cli.version>1.4</commons-cli.version>
 		<postgresql.version>42.2.19.jre6</postgresql.version><!--42.2.14.jre6 last
     version-->
-		<oracle.version>6</oracle.version>
+		<oracle.version>11.2.0.4</oracle.version>
 		<jaxen.version>1.2.0</jaxen.version>
 		<xerces.version>2.12.1</xerces.version>
 		<javasysmon.version>0.3.6</javasysmon.version>
@@ -638,6 +638,7 @@
 										<exclude>org.apache.ant</exclude>
 										<exclude>Oracle</exclude>
 										<exclude>com.oracle.jdbc</exclude>
+										<exclude>com.oracle.database.jdbc</exclude>
 									</excludes>
 								</artifactSet>
 							</configuration>
@@ -1331,7 +1332,7 @@
 				<h2.version>1.4.200</h2.version><!--Java6 version -->
 				<mariadb.version>2.5.4</mariadb.version>
 				<mysql.version>8.0.20</mysql.version>
-				<oracle.version>6</oracle.version>
+				<oracle.version>11.2.0.4</oracle.version>
 				<jackson.version>2.12.1</jackson.version><!--Java6 version -->
 				<jackson-databind.version>2.12.1</jackson-databind.version><!--Java6
 		version -->
@@ -2149,7 +2150,7 @@
 				<version>${mysql.version}</version>
 			</dependency>
 			<dependency>
-				<groupId>Oracle</groupId>
+				<groupId>com.oracle.database.jdbc</groupId>
 				<artifactId>ojdbc6</artifactId>
 				<version>${oracle.version}</version>
 				<optional>true</optional>


### PR DESCRIPTION
Use latest version of Oracle JDBC driver 6 from Maven Central.

See:
- https://www.oracle.com/database/technologies/maven-central-guide.html
- https://www.oracle.com/database/technologies/faq-jdbc.html#Q8

I run `mvn clean package -P jre11,integration-tests` to test this PR and if needed I can run with other profiles such as `jre6` or `jre8`.

I have created this PR to prevent build failure if dependency is not available (i.e. manually installed) in local Maven repository.