### PR TITLE
Remove prefix when adding resources to jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -892,7 +892,6 @@
                         <include name="**"/>
                       </zipfileset>
                       <zipfileset dir="${basedir}/target/resources"
-                                  prefix="./"
                                   erroronmissingarchive="false"/>
                       <zipfileset filemode="644"
                                   src="${project.build.directory}/${project.build.finalName}.orig.jar"
@@ -918,7 +917,6 @@
                         <include name="**"/>
                       </zipfileset>
                       <zipfileset dir="${basedir}/target/resources"
-                                  prefix="./"
                                   erroronmissingarchive="false"/>
                       <zipfileset filemode="644"
                                   src="${project.build.directory}/${project.build.finalName}-sources.orig.jar"


### PR DESCRIPTION
Remove the prefix `./` avoid the creation of a folder named `./` in the built jar file. Having a folder with such name lead to an error when building on Java 11 due to changes introduced to fix https://bugs.openjdk.org/browse/JDK-8251329.
More information are available at: https://stackoverflow.com/a/72168772/2440340

I run successfully all the tests With Maven 3.9.1 and openjdk 11.0.18.

It should fix the issue mentioned in the releasing process documentation https://github.com/waarp/Waarp-All/blob/v3.6/doc/releasing.md?plain=1#L11

Here are the details of the content of `WaarpDigest-3.6.2-jre11.jar` before:
```
Archive:  ./WaarpDigest/target/WaarpDigest-3.6.2-jre11.jar
  Length      Date    Time    Name
---------  ---------- -----   ----
        0  2023-03-30 11:39   META-INF/
      723  2021-03-03 16:18   META-INF/COPYRIGHT.txt
    33315  2021-03-03 16:18   META-INF/LICENSE.txt
     2870  2021-03-03 16:18   META-INF/NOTICE.txt
        0  2023-03-30 11:39   META-INF/license/
     2081  2021-03-03 16:18   META-INF/license/LICENSE.fastmd5.txt
        0  2023-03-30 11:39   ./
      932  2023-03-30 11:39   ./project.properties
        0  2023-03-30 11:39   META-INF/maven/
        0  2023-03-30 11:39   META-INF/maven/Waarp/
        0  2023-03-30 11:39   META-INF/maven/Waarp/WaarpDigest/
        0  2023-03-30 11:39   org/
        0  2023-03-30 11:39   org/waarp/
        0  2023-03-30 11:39   org/waarp/common/
        0  2023-03-30 11:39   org/waarp/common/digest/
       81  2023-03-30 11:39   META-INF/MANIFEST.MF
       57  2023-03-30 11:39   META-INF/maven/Waarp/WaarpDigest/pom.properties
     4107  2021-08-03 19:28   META-INF/maven/Waarp/WaarpDigest/pom.xml
     1141  2023-03-30 11:39   org/waarp/common/digest/FilesystemBasedDigest$1.class
     2375  2023-03-30 11:39   org/waarp/common/digest/FilesystemBasedDigest$DigestAlgo.class
    10198  2023-03-30 11:39   org/waarp/common/digest/FilesystemBasedDigest.class
      926  2023-03-30 11:39   org/waarp/common/digest/WaarpBC$1.class
     5856  2023-03-30 11:39   org/waarp/common/digest/WaarpBC.class
      129  2023-03-30 11:39   org/waarp/common/digest/package-info.class
      915  2023-03-30 11:39   project.properties
---------                     -------
    65706                     25 files
```

and after:
```
Archive:  ./WaarpDigest/target/WaarpDigest-3.6.2-jre11.jar
  Length      Date    Time    Name
---------  ---------- -----   ----
        0  2023-03-30 11:41   META-INF/
      723  2021-03-03 16:18   META-INF/COPYRIGHT.txt
    33315  2021-03-03 16:18   META-INF/LICENSE.txt
     2870  2021-03-03 16:18   META-INF/NOTICE.txt
        0  2023-03-30 11:41   META-INF/license/
     2081  2021-03-03 16:18   META-INF/license/LICENSE.fastmd5.txt
      932  2023-03-30 11:41   project.properties
        0  2023-03-30 11:41   META-INF/maven/
        0  2023-03-30 11:41   META-INF/maven/Waarp/
        0  2023-03-30 11:41   META-INF/maven/Waarp/WaarpDigest/
        0  2023-03-30 11:41   org/
        0  2023-03-30 11:41   org/waarp/
        0  2023-03-30 11:41   org/waarp/common/
        0  2023-03-30 11:41   org/waarp/common/digest/
       81  2023-03-30 11:41   META-INF/MANIFEST.MF
       57  2023-03-30 11:41   META-INF/maven/Waarp/WaarpDigest/pom.properties
     4107  2021-08-03 19:28   META-INF/maven/Waarp/WaarpDigest/pom.xml
     1141  2023-03-30 11:41   org/waarp/common/digest/FilesystemBasedDigest$1.class
     2375  2023-03-30 11:41   org/waarp/common/digest/FilesystemBasedDigest$DigestAlgo.class
    10198  2023-03-30 11:41   org/waarp/common/digest/FilesystemBasedDigest.class
      926  2023-03-30 11:41   org/waarp/common/digest/WaarpBC$1.class
     5856  2023-03-30 11:41   org/waarp/common/digest/WaarpBC.class
      129  2023-03-30 11:41   org/waarp/common/digest/package-info.class
      915  2023-03-30 11:41   project.properties
---------                     -------
    65706                     24 files
```