### PR TITLE
Various small improvements

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,6 +13,5 @@
 *.png binary
 *.jpg binary
 *.jar binary
-lib/phantomjs* binary
 lib/geckodriver* binary
 

--- a/WaarpCommon/pom.xml
+++ b/WaarpCommon/pom.xml
@@ -307,11 +307,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.detro</groupId>
-      <artifactId>ghostdriver</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
       <artifactId>htmlunit-driver</artifactId>
       <scope>test</scope>

--- a/WaarpCommon/src/test/java/org/waarp/common/file/FileUtilsTest.java
+++ b/WaarpCommon/src/test/java/org/waarp/common/file/FileUtilsTest.java
@@ -104,10 +104,10 @@ public class FileUtilsTest {
     final ClassLoader classLoader = FileUtilsTest.class.getClassLoader();
     File file = new File(classLoader.getResource("cert.jks").getFile());
     file = file.getParentFile().getParentFile().getParentFile().getParentFile();
-    file = new File(file, "lib/phantomjs-2.1.1.bz2");
+    file = new File(file, "lib/geckodriver.bz2");
     SysErrLogger.FAKE_LOGGER.sysout(file.getAbsolutePath());
     assertTrue(file.canRead());
-    File to = new File("/tmp/phantomjs-2.1.1");
+    File to = new File("/tmp/geckodriver.bz2");
     if (to.exists()) {
       to.delete();
     }

--- a/WaarpGatewayFtp/pom.xml
+++ b/WaarpGatewayFtp/pom.xml
@@ -357,11 +357,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.detro</groupId>
-      <artifactId>ghostdriver</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
       <artifactId>htmlunit-driver</artifactId>
       <scope>test</scope>

--- a/WaarpGatewayFtp/src/test/java/org/waarp/gateway/ftp/client/FtpClientPostgreTest.java
+++ b/WaarpGatewayFtp/src/test/java/org/waarp/gateway/ftp/client/FtpClientPostgreTest.java
@@ -260,7 +260,6 @@ public class FtpClientPostgreTest extends TestWebAbstract {
       }
     }
     if (file.exists()) {
-      driverType = DriverType.FIREFOX;
       initiateWebDriver(file.getParentFile());
     }
     final File tmp = new File("/tmp");

--- a/WaarpGatewayFtp/src/test/java/org/waarp/gateway/ftp/client/FtpClientTest.java
+++ b/WaarpGatewayFtp/src/test/java/org/waarp/gateway/ftp/client/FtpClientTest.java
@@ -181,7 +181,6 @@ public class FtpClientTest extends TestWebAbstract {
     final ClassLoader classLoader = FtpClientTest.class.getClassLoader();
     File file = new File(classLoader.getResource("Gg-FTP.xml").getFile());
     if (file.exists()) {
-      driverType = DriverType.FIREFOX;
       initiateWebDriver(file.getParentFile());
     }
     final File tmp = new File("/tmp");

--- a/WaarpHttp/pom.xml
+++ b/WaarpHttp/pom.xml
@@ -398,11 +398,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.detro</groupId>
-      <artifactId>ghostdriver</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
       <artifactId>htmlunit-driver</artifactId>
       <scope>test</scope>

--- a/WaarpProxyR66/pom.xml
+++ b/WaarpProxyR66/pom.xml
@@ -382,11 +382,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.detro</groupId>
-      <artifactId>ghostdriver</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
       <artifactId>htmlunit-driver</artifactId>
       <scope>test</scope>

--- a/WaarpR66-Extensions/pom.xml
+++ b/WaarpR66-Extensions/pom.xml
@@ -484,11 +484,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.detro</groupId>
-      <artifactId>ghostdriver</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
       <artifactId>htmlunit-driver</artifactId>
       <scope>test</scope>

--- a/WaarpR66/pom.xml
+++ b/WaarpR66/pom.xml
@@ -440,11 +440,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.detro</groupId>
-      <artifactId>ghostdriver</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
       <artifactId>htmlunit-driver</artifactId>
       <scope>test</scope>

--- a/WaarpR66/pom.xml
+++ b/WaarpR66/pom.xml
@@ -423,7 +423,7 @@
       <artifactId>WaarpCommon</artifactId>
       <classifier>tests</classifier>
       <type>test-jar</type>
-      <version>${revision}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -431,7 +431,7 @@
       <artifactId>WaarpIcap</artifactId>
       <classifier>tests</classifier>
       <type>test-jar</type>
-      <version>${revision}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/WaarpR66/src/test/java/org/waarp/openr66/protocol/it/AdminIT.java
+++ b/WaarpR66/src/test/java/org/waarp/openr66/protocol/it/AdminIT.java
@@ -87,7 +87,6 @@ public class AdminIT extends TestAbstract {
     final File file =
         new File(classLoader.getResource("logback-test.xml").getFile());
     if (file.exists()) {
-      TestWebAbstract.driverType = TestWebAbstract.DriverType.FIREFOX;
       TestWebAbstract.initiateWebDriver(file.getParentFile());
     }
     setUpDbBeforeClass();

--- a/WaarpR66/src/test/java/org/waarp/openr66/protocol/junit/AdminResponsiveTest.java
+++ b/WaarpR66/src/test/java/org/waarp/openr66/protocol/junit/AdminResponsiveTest.java
@@ -77,7 +77,6 @@ public class AdminResponsiveTest extends TestAbstract {
     final File file =
         new File(classLoader.getResource("logback-test.xml").getFile());
     if (file.exists()) {
-      TestWebAbstract.driverType = TestWebAbstract.DriverType.FIREFOX;
       try {
         TestWebAbstract.initiateWebDriver(file.getParentFile());
       } catch (NoSuchMethodError e) {

--- a/WaarpR66/src/test/java/org/waarp/openr66/protocol/junit/AdminTest.java
+++ b/WaarpR66/src/test/java/org/waarp/openr66/protocol/junit/AdminTest.java
@@ -78,7 +78,6 @@ public class AdminTest extends TestAbstract {
     final File file =
         new File(classLoader.getResource("logback-test.xml").getFile());
     if (file.exists()) {
-      TestWebAbstract.driverType = TestWebAbstract.DriverType.FIREFOX;
       try {
         TestWebAbstract.initiateWebDriver(file.getParentFile());
       } catch (NoSuchMethodError e) {

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
     <repository>
       <id>jboss org</id>
       <name>Jboss org</name>
-      <url>http://repository.jboss.org/nexus/content/groups/public</url>
+      <url>https://repository.jboss.org/nexus/content/groups/public</url>
       <releases>
         <enabled>true</enabled>
       </releases>
@@ -110,7 +110,7 @@
     <repository>
       <id>com.anasoft.os.repository.releases</id>
       <name>ANASOFT OpenSource releases</name>
-      <url>http://anasoft-os-repo.googlecode.com/svn/repository/releases</url>
+      <url>https://anasoft-os-repo.googlecode.com/svn/repository/releases</url>
       <releases>
         <enabled>true</enabled>
       </releases>
@@ -142,7 +142,7 @@
     <repository>
       <id>eaio.com</id>
       <name>EAIO</name>
-      <url>http://eaio.com/maven2</url>
+      <url>https://eaio.com/maven2</url>
       <releases>
         <enabled>true</enabled>
       </releases>

--- a/pom.xml
+++ b/pom.xml
@@ -342,7 +342,7 @@
     <build-helper-maven-plugin.version>3.3.0</build-helper-maven-plugin.version><!--
 			1.9 -->
     <license-maven-plugin.version>2.0.0</license-maven-plugin.version>
-    <maven-enforcer-plugin.version>3.0.0
+    <maven-enforcer-plugin.version>3.2.1
     </maven-enforcer-plugin.version><!-- 1.3.1 -->
     <versions-maven-plugin.version>2.9.0</versions-maven-plugin.version>
     <animal-sniffer-enforcer-rule.version>1.21
@@ -359,7 +359,7 @@
     <jdeb.vafer.version>1.10</jdeb.vafer.version>
     <maven.rpm-maven-plugin.version>2.2.0</maven.rpm-maven-plugin.version>
     <exec.maven.version>3.0.0</exec.maven.version>
-    <extra-enforcer-rules.version>1.6.0</extra-enforcer-rules.version>
+    <extra-enforcer-rules.version>1.6.2</extra-enforcer-rules.version>
     <maven-deploy-plugin.version>3.0.0-M2</maven-deploy-plugin.version>
     <maven.flatten-maven-plugin.version>1.4.1</maven.flatten-maven-plugin.version>
     <asm.version>9.3</asm.version>

--- a/pom.xml
+++ b/pom.xml
@@ -151,11 +151,6 @@
       </snapshots>
     </repository>
     <repository>
-      <name>PhantomJS</name>
-      <id>jitpack.io</id>
-      <url>https://jitpack.io</url>
-    </repository>
-    <repository>
       <!-- This repository refers to lib directory such that no need to install
         locally those extra dependencies -->
       <id>Local repository</id>
@@ -3391,18 +3386,6 @@
           <exclusion>
             <groupId>io.netty</groupId>
             <artifactId>netty-transport-classes-kqueue</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>com.github.detro</groupId>
-        <artifactId>ghostdriver</artifactId>
-        <version>2.1.0</version>
-        <scope>test</scope>
-        <exclusions>
-          <exclusion>
-            <groupId>org.seleniumhq.selenium</groupId>
-            <artifactId>selenium-remote-driver</artifactId>
           </exclusion>
         </exclusions>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -361,6 +361,7 @@
     <exec.maven.version>3.0.0</exec.maven.version>
     <extra-enforcer-rules.version>1.6.0</extra-enforcer-rules.version>
     <maven-deploy-plugin.version>3.0.0-M2</maven-deploy-plugin.version>
+    <maven.flatten-maven-plugin.version>1.4.1</maven.flatten-maven-plugin.version>
     <asm.version>9.3</asm.version>
   </properties>
 
@@ -685,6 +686,12 @@
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>exec-maven-plugin</artifactId>
           <version>${exec.maven.version}</version>
+        </plugin>
+        
+        <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>flatten-maven-plugin</artifactId>
+            <version>${maven.flatten-maven-plugin.version}</version>
         </plugin>
       </plugins>
 
@@ -1022,6 +1029,30 @@
           <updateReleaseInfo>true</updateReleaseInfo>
         </configuration>
       </plugin>
+        <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>flatten-maven-plugin</artifactId>
+            <configuration>
+                <updatePomFile>true</updatePomFile>
+                <flattenMode>resolveCiFriendliesOnly</flattenMode>
+            </configuration>
+            <executions>
+                <execution>
+                <id>flatten</id>
+                <phase>process-resources</phase>
+                <goals>
+                    <goal>flatten</goal>
+                </goals>
+                </execution>
+                <execution>
+                <id>flatten.clean</id>
+                <phase>clean</phase>
+                <goals>
+                    <goal>clean</goal>
+                </goals>
+                </execution>
+            </executions>
+        </plugin>
     </plugins>
     <resources>
       <resource>

--- a/pom.xml
+++ b/pom.xml
@@ -892,7 +892,6 @@
                         <include name="**"/>
                       </zipfileset>
                       <zipfileset dir="${basedir}/target/resources"
-                                  prefix="./"
                                   erroronmissingarchive="false"/>
                       <zipfileset filemode="644"
                                   src="${project.build.directory}/${project.build.finalName}.orig.jar"
@@ -918,7 +917,6 @@
                         <include name="**"/>
                       </zipfileset>
                       <zipfileset dir="${basedir}/target/resources"
-                                  prefix="./"
                                   erroronmissingarchive="false"/>
                       <zipfileset filemode="644"
                                   src="${project.build.directory}/${project.build.finalName}-sources.orig.jar"


### PR DESCRIPTION
This PR try to fix various minor issues:
- Use HTTPS for third party Maven repositories URL to avoid the need of specific configuration with recent Maven versions.
- Follow recommendation from [https://maven.apache.org/maven-ci-friendly.html](https://maven.apache.org/maven-ci-friendly.html#dependencies) to allow individual module build.
- Update extra-enforcer-rules Maven plugin to benefit from bug fix.
- Remove usage of PhantomJS as Selenium drop support of PhantomJS in version 3.8.0.

Each commit have comments with more details about what have been done.

This PR also include a commit (775b995faec7faa8bd5eb411c6e82e1db73037b3) that is part of #112.