### PR TITLE
Fix generation of JaCoCo when building for Java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1544,7 +1544,7 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
               <argLine>
-                --illegal-access=permit
+                @{argLine} --illegal-access=permit
               </argLine>
             </configuration>
           </plugin>


### PR DESCRIPTION
Configuration of surefire plugin includes `<argLine>` and this currently overide property defined by JaCoCo. Applying recommendation from https://www.jacoco.org/jacoco/trunk/doc/prepare-agent-mojo.html to fix that.